### PR TITLE
9 add a long text smoke test

### DIFF
--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -48,3 +48,7 @@ jobs:
       timeout-minutes: 60
       run: |
         python3 quick_demo_cpu_titans_mem.py
+    - name: Smoke Test Training with Datasets
+      timeout-minutes: 90
+      run: |
+        python3 train-with-dataset-cicd-test.py

--- a/README.md
+++ b/README.md
@@ -150,17 +150,18 @@ Recurrent loops reuse weights (depth without parameter growth). Graph wiring cre
 
 Because the graph is the bulk of the model, parameter counts are shown for **two common vocabularies**: a minimal character-level vocab (~100 tokens) and the GPT-2 BPE vocab (50,257 tokens). Both assume **tied embeddings/head**.
 
-| Preset | d_model | Columns | Heads | Loops | SSM | **~Params (Char)** | **~Params (GPT-2)** | Seq Len | Use Case |
-|--------|---------|---------|-------|-------|-----|-------------------|---------------------|---------|----------|
-| `tiny` | 128 | 2 | 4 | 1 | No | **496,006** | **20M** | 256 | Smoke test |
-| `small` | 256 | 3 | 4 | 2 | No | **-** | **-** | 512 | Experiments |
-| `base` | 512 | 4 | 8 | 2 | Yes | **-** | **-** | 1024 | Serious pretraining |
-| `medium` | 768 | 5 | 12 | 3 | Yes | **-** | **-** | 2048 | Production small |
-| `large` | 1024 | 6 | 16 | 3 | Yes | **-** | **-** | 4096 | Competitive |
-| `xl` | 1536 | 6 | 24 | 4 | Yes | **-** | **-** | 8192 | Frontier small |
-| `xxl` | 2048 | 7 | 32 | 4 | Yes | **-** | **-** | 16384 | Near-frontier |
+## Parameter Scaling
 
-> **How to read the table:** At small scale the GPT-2 embedding dominates the parameter budget. At `xxl`, the heterogeneous graph dominates (~1.24B) and the vocabulary adds only ~8%. If you train on a custom tiny vocabulary, you can cut millions to billions of parameters from the embedding layer.
+| Preset | d_model | ~Params (Char) | ~Params (GPT-2) | Status |
+|--------|---------|---------------|-----------------|--------|
+| **tiny** | 128 | 0.5 M | **13 M** | Smoke tests + demos |
+| **small** | 256 | 3.2 M | 29 M | Experiments |
+| **base** | 512 | 32 M | 83 M | Serious pretraining |
+| **medium** | 768 | ~134 M | ~211 M | Production small |
+| **large** | 1 024 | ~286 M | ~389 M | Competitive |
+| **xl** | 1 536 | ~1.1 B | ~1.2 B | Frontier small |
+| **xxl** | 2 048 | ~2.7 B | ~2.9 B | Frontier |
+
 
 ```python
 # One-liner scaling

--- a/examples/train_hf_full.py
+++ b/examples/train_hf_full.py
@@ -4,7 +4,7 @@ Example: Training HelixLM with HuggingFace integration.
 Demonstrates:
   - GPT-2 tokenizer
   - HelixForCausalLM HF model
-  - Streaming dataset
+  - Document-aware dataset with lazy loading
   - save_pretrained / push_to_hub
 """
 import os
@@ -21,6 +21,7 @@ def main():
         vocab_size=50257,
         seq_len=256,
         tokenizer_name="gpt2",
+        use_titans_memory=False,
     )
 
     # Tokenizer
@@ -60,7 +61,7 @@ def main():
     # Generate
     print("\n--- Generation ---")
     prompt = "In 1492,"
-    input_ids = torch.tensor([tokenizer.encode(prompt)]).to(model.device)
+    input_ids = tokenizer.encode(prompt, return_tensors="pt").to(model.device)
     generated = model.generate_ext(input_ids, max_new_tokens=20, temperature=0.8)
     text = tokenizer.decode(generated[0], skip_special_tokens=True)
     print(f"  '{prompt}' -> '{text}'")

--- a/helix_lm/config.py
+++ b/helix_lm/config.py
@@ -201,7 +201,10 @@ class HelixConfig(PretrainedConfig):
         self.grad_clip = grad_clip
         self.initializer_range = initializer_range
         self.device = device
-        self.dtype = getattr(torch, dtype) if isinstance(dtype, str) else dtype
+        if isinstance(dtype, str):
+            self.dtype = getattr(torch, dtype.replace("torch.", ""))
+        else:
+            self.dtype = dtype
 
         # --- Tokenizer ---
         self.tokenizer_name = tokenizer_name
@@ -272,7 +275,7 @@ class HelixConfig(PretrainedConfig):
 
     def to_dict(self) -> Dict[str, Any]:
         d = super().to_dict()
-        d["dtype"] = str(self.dtype)
+        d["dtype"] = str(self.dtype).replace("torch.", "")
         return d
 
     @classmethod

--- a/helix_lm/config.py
+++ b/helix_lm/config.py
@@ -129,6 +129,9 @@ class HelixConfig(PretrainedConfig):
         vision_num_attention_heads: int = 16,
         fusion_strategy: str = "perceiver",  # "perceiver", "simple_merge"
 
+        # memory
+        memory_efficient_forward: bool = False
+        
         # --- Misc ---
         tie_word_embeddings: bool = True,
         **kwargs,
@@ -225,6 +228,9 @@ class HelixConfig(PretrainedConfig):
         self.vision_intermediate_size = vision_intermediate_size
         self.vision_num_attention_heads = vision_num_attention_heads
         self.fusion_strategy = fusion_strategy
+
+        # memory
+        self.memory_efficient_forward = memory_efficient_forward
 
         # --- Validation ---
         assert self.d_model % self.n_heads == 0, "d_model must be divisible by n_heads"

--- a/helix_lm/config.py
+++ b/helix_lm/config.py
@@ -130,7 +130,7 @@ class HelixConfig(PretrainedConfig):
         fusion_strategy: str = "perceiver",  # "perceiver", "simple_merge"
 
         # memory
-        memory_efficient_forward: bool = False
+        memory_efficient_forward: bool = False,
         
         # --- Misc ---
         tie_word_embeddings: bool = True,

--- a/helix_lm/config.py
+++ b/helix_lm/config.py
@@ -61,7 +61,7 @@ class HelixConfig(PretrainedConfig):
         ssm_bias: bool = False,
 
         # --- Titans Neural Memory ---
-        use_titans_memory: bool = False,
+        use_titans_memory: bool = True,
         titans_feature_dim: int = 64,
         titans_eta_init: float = 0.01,
         titans_n_heads: int = 4,

--- a/helix_lm/dataset.py
+++ b/helix_lm/dataset.py
@@ -1,14 +1,16 @@
 """
 HelixLM Dataset with rolling text chunking and natural stop detection.
 
-Key features:
-  - Rolling window for text > MAX_SEQ_LEN: overlapping chunks with stride
-  - Padding for text < MAX_SEQ_LEN
-  - Distinguishes natural stop (end of document) from EOS token
-  - Supports both raw text and pre-tokenized inputs
-  - Compatible with HF datasets streaming interface
-  - Document-aware chunking: no cross-document boundaries, 100% token utilization
-  - Optional lazy loading: O(1) init, tokenize on-the-fly
+Key fixes in this revision
+  * DocumentAwareDataset now tracks exact pad_len in every chunk tuple.
+    It NEVER scans backwards for pad_token_id, so GPT-2 (pad_id == eos_id)
+    cannot accidentally mask a real EOS.
+  * Optional within-document overlap (stride) added to DocumentAwareDataset.
+    stride == seq_len  -> non-overlapping (default).
+    stride <  seq_len  -> overlapping windows; overlap is masked in labels.
+  * No cross-document boundaries are ever crossed.
+
+Compatible with both eager and lazy loading.
 """
 import random
 from typing import List, Optional, Iterator, Dict, Any, Union, Tuple
@@ -33,16 +35,6 @@ class HelixDataset(Dataset):
       - labels: (seq_len,) — shifted by 1 for next-token prediction
       - attention_mask: (seq_len,) — 1 for real tokens, 0 for padding
       - is_natural_stop: scalar bool — True if chunk ends at document boundary
-
-    Args:
-        texts: List of document texts.
-        tokenizer: Tokenizer instance.
-        seq_len: Target sequence length.
-        stride: Rolling window stride. Default: seq_len // 2.
-        lazy: If True, store raw texts and tokenize on-the-fly in __getitem__.
-              If False, eagerly tokenize all documents in __init__.
-        add_eos: Whether to append EOS token to each document.
-        natural_stop_threshold: Fraction of document length to consider as natural stop.
     """
     def __init__(
         self,
@@ -64,29 +56,25 @@ class HelixDataset(Dataset):
         self.natural_stop_threshold = natural_stop_threshold
 
         if lazy:
-            # O(1) init: just store texts
             self._tokenized_docs = None
             self._chunk_index = None
         else:
-            # Eager tokenization with progress bar
             self._tokenized_docs = self._tokenize_all()
             self._chunk_index = self._build_chunk_index()
 
     def _tokenize_all(self) -> List[Dict[str, Any]]:
-        """Pre-tokenize all documents, storing per-document token lists."""
         docs = []
         iterable = tqdm(self.texts, desc="Tokenizing", unit="doc", disable=len(self.texts) < 1000)
         for text in iterable:
             if not text.strip():
                 continue
             ids = self.tokenizer.encode(text, add_special_tokens=False)
-            if self.add_eos and hasattr(self.tokenizer, 'eos_token_id'):
+            if self.add_eos and hasattr(self.tokenizer, 'eos_token_id') and self.tokenizer.eos_token_id is not None:
                 ids.append(self.tokenizer.eos_token_id)
             docs.append({"ids": ids, "length": len(ids)})
         return docs
 
     def _build_chunk_index(self) -> List[Tuple[int, int, bool]]:
-        """Build (doc_idx, start_idx, is_natural_stop) for every chunk."""
         index = []
         for doc_idx, doc in enumerate(self._tokenized_docs):
             length = doc["length"]
@@ -105,16 +93,13 @@ class HelixDataset(Dataset):
         return index
 
     def _build_lazy_chunk_index(self) -> List[Tuple[int, int, int, bool]]:
-        """Build chunk index from raw texts on-the-fly.
-        Returns (doc_idx, start_idx, effective_len, is_natural_stop).
-        """
         index = []
         for doc_idx, text in enumerate(self.texts):
             text = text.strip()
             if not text:
                 continue
             ids = self.tokenizer.encode(text, add_special_tokens=False)
-            if self.add_eos and hasattr(self.tokenizer, 'eos_token_id'):
+            if self.add_eos and hasattr(self.tokenizer, 'eos_token_id') and self.tokenizer.eos_token_id is not None:
                 ids.append(self.tokenizer.eos_token_id)
             length = len(ids)
             if length == 0:
@@ -133,7 +118,6 @@ class HelixDataset(Dataset):
     def __len__(self) -> int:
         if self._chunk_index is not None:
             return len(self._chunk_index)
-        # Lazy mode: build index on first len() call and cache it
         if not hasattr(self, '_lazy_index') or self._lazy_index is None:
             self._lazy_index = self._build_lazy_chunk_index()
         return len(self._lazy_index)
@@ -149,7 +133,7 @@ class HelixDataset(Dataset):
             doc_idx, start_idx, length, is_natural_stop = self._lazy_index[idx]
             text = self.texts[doc_idx].strip()
             ids = self.tokenizer.encode(text, add_special_tokens=False)
-            if self.add_eos and hasattr(self.tokenizer, 'eos_token_id'):
+            if self.add_eos and hasattr(self.tokenizer, 'eos_token_id') and self.tokenizer.eos_token_id is not None:
                 ids.append(self.tokenizer.eos_token_id)
 
         if length >= self.seq_len:
@@ -172,7 +156,6 @@ class HelixDataset(Dataset):
     def _make_sample(self, chunk, labels, is_natural_stop):
         input_ids = torch.tensor(chunk[:self.seq_len], dtype=torch.long)
         labels_t = torch.tensor(labels[:self.seq_len], dtype=torch.long)
-        # DO NOT blanket-mask pad_token_id here — pad_token_id may equal eos_token_id.
         attention_mask = (input_ids != self.tokenizer.pad_token_id).long()
         return {
             "input_ids": input_ids,
@@ -186,30 +169,46 @@ class DocumentAwareDataset(Dataset):
     """
     Per-document chunking with no cross-document boundaries.
 
-    For each document:
-      - Long documents: split into non-overlapping seq_len chunks.
-      - Short documents: kept as-is, padded to seq_len.
-      - Final chunk of each document is marked is_natural_stop=True.
-      - Only padding positions are masked in labels (-100).
-      - No label masking for overlap regions (100% token utilization).
+    Chunk tuple format (built in _build_chunks):
+        (token_ids, is_natural_stop, pad_len, overlap_mask_len)
 
-    Args:
-        texts: List of document texts.
-        tokenizer: Tokenizer with encode(), pad_token_id, eos_token_id.
-        seq_len: Target sequence length for all chunks.
-        min_tail_len: Minimum length for a tail chunk to be kept.
-                      Default: seq_len // 4.
-                      Set to 1 to keep all tails (e.g., for instruct data).
-        add_eos: Whether to append EOS token to each document.
-        lazy: If True, store raw texts and build chunks on-the-fly.
-              If False, eagerly tokenize all documents in __init__.
+      * pad_len: exact number of padded positions at the TAIL.
+                 Used to set labels[-pad_len:] = -100.
+                 Always 0 for full chunks.
+      * overlap_mask_len: number of positions at the HEAD to mask with -100.
+                 Used when stride < seq_len so overlapping tokens are not
+                 double-counted in loss. Always 0 when stride == seq_len.
+
+    For each document:
+      - Long documents: split into seq_len chunks (optionally overlapping).
+      - Short documents: kept as-is, padded to seq_len.
+      - Only padding positions are masked in labels (-100).
+      - No label masking for overlap regions except the explicit overlap head.
     """
-    def __init__(self, texts, tokenizer, seq_len, min_tail_len=None, add_eos=True, lazy=True):
+    def __init__(
+        self,
+        texts,
+        tokenizer,
+        seq_len,
+        min_tail_len=None,
+        add_eos=True,
+        lazy=True,
+        stride: Optional[int] = None,
+    ):
+        super().__init__()
         self.seq_len = seq_len
         self.tokenizer = tokenizer
-        self.pad_id = getattr(tokenizer, "pad_token_id", 0)
-        self.eos_id = getattr(tokenizer, "eos_token_id", self.pad_id)
+
+        # Robust pad_id fallback: if unset, fall back to eos_id, then 0.
+        self.pad_id = getattr(tokenizer, "pad_token_id", None)
+        if self.pad_id is None:
+            self.pad_id = getattr(tokenizer, "eos_token_id", 0)
+        self.eos_id = getattr(tokenizer, "eos_token_id", None)
+
         self.lazy = lazy
+        self.stride = stride if stride is not None else seq_len
+        if not (1 <= self.stride <= self.seq_len):
+            raise ValueError(f"stride must be in [1, seq_len], got {self.stride}")
 
         if min_tail_len is None:
             min_tail_len = seq_len // 4
@@ -225,14 +224,15 @@ class DocumentAwareDataset(Dataset):
             self.chunks, self._stats = self._build_chunks(texts)
 
     def _build_chunks(self, texts):
-        """Eagerly build chunks from texts. Returns (chunks, stats)."""
+        """
+        Build chunk tuples:
+          (token_ids: List[int], is_natural: bool, pad_len: int, overlap_mask: int)
+        """
         chunks = []
-        dropped_short = 0
-        dropped_tail = 0
-        kept = 0
+        dropped_short = dropped_tail = kept = 0
+        stride = self.stride
 
-        iterable = tqdm(texts, desc="Chunking", unit="doc", disable=len(texts) < 1000)
-        for text in iterable:
+        for text in tqdm(texts, desc="Chunking", unit="doc", disable=len(texts) < 1000):
             text = text.strip()
             if not text:
                 continue
@@ -245,24 +245,55 @@ class DocumentAwareDataset(Dataset):
             if self.add_eos and self.eos_id is not None:
                 ids.append(self.eos_id)
 
-            n_full = len(ids) // self.seq_len
-            remainder_len = len(ids) % self.seq_len
+            length = len(ids)
 
-            for i in range(n_full):
-                start = i * self.seq_len
-                chunk = ids[start:start + self.seq_len]
-                is_last_chunk = (i == n_full - 1)
-                no_tail_kept = (remainder_len < self.min_tail_len)
-                chunks.append((chunk, is_last_chunk and no_tail_kept))
-                kept += 1
+            if length >= self.seq_len:
+                # Sliding-window chunks fully inside the document
+                starts = list(range(0, length - self.seq_len + 1, stride))
+                for i, start in enumerate(starts):
+                    chunk = ids[start:start + self.seq_len]
+                    is_last_start = (i == len(starts) - 1)
+                    reaches_end = (start + self.seq_len == length)
 
-            if remainder_len >= self.min_tail_len:
-                tail = ids[n_full * self.seq_len:]
-                tail = tail + [self.pad_id] * (self.seq_len - remainder_len)
-                chunks.append((tail, True))
+                    # Natural stop logic: if this is the last chunk we will emit
+                    # and there is no tail (or tail is too short), mark it.
+                    if not is_last_start:
+                        is_natural = False
+                    else:
+                        tail_len = length - (start + self.seq_len)
+                        has_tail = tail_len >= self.min_tail_len
+                        is_natural = reaches_end or (not has_tail)
+
+                    overlap_mask = 0
+                    if start > 0 and stride < self.seq_len:
+                        overlap_mask = self.seq_len - stride
+
+                    chunks.append((chunk, is_natural, 0, overlap_mask))
+                    kept += 1
+
+                # Tail: tokens after the last sliding chunk
+                last_covered_end = starts[-1] + self.seq_len if starts else 0
+                remainder_len = length - last_covered_end
+
+                if remainder_len >= self.min_tail_len:
+                    tail = ids[last_covered_end:]
+                    pad_len = self.seq_len - remainder_len
+                    tail = tail + [self.pad_id] * pad_len
+                    chunks.append((tail, True, pad_len, 0))
+                    kept += 1
+                elif remainder_len > 0:
+                    # Tail too short to keep: last sliding chunk becomes the doc end
+                    if starts:
+                        last_chunk, _, last_pad, last_overlap = chunks[-1]
+                        chunks[-1] = (last_chunk, True, last_pad, last_overlap)
+                    dropped_tail += 1
+
+            else:
+                # Short document: pad once, everything is a natural stop
+                pad_len = self.seq_len - length
+                chunk = ids + [self.pad_id] * pad_len
+                chunks.append((chunk, True, pad_len, 0))
                 kept += 1
-            elif remainder_len > 0:
-                dropped_tail += 1
 
         stats = {
             "kept": kept,
@@ -272,7 +303,6 @@ class DocumentAwareDataset(Dataset):
         return chunks, stats
 
     def _ensure_chunks(self):
-        """Lazy build chunks on first access."""
         if self.chunks is None:
             self.chunks, self._stats = self._build_chunks(self.texts)
             self.texts = None  # free memory
@@ -283,17 +313,16 @@ class DocumentAwareDataset(Dataset):
 
     def __getitem__(self, idx):
         self._ensure_chunks()
-        chunk, is_natural = self.chunks[idx]
+        chunk, is_natural, pad_len, overlap_mask = self.chunks[idx]
+
         x = torch.tensor(chunk, dtype=torch.long)
         labels = x.clone()
 
-        # Only mask trailing padding we actually appended in _build_chunks
-        pad_len = 0
-        for i in reversed(range(len(chunk))):
-            if chunk[i] == self.pad_id:
-                pad_len += 1
-            else:
-                break
+        # 1. Mask overlapping head (only when stride < seq_len)
+        if overlap_mask > 0:
+            labels[:overlap_mask] = -100
+
+        # 2. Mask exact trailing padding count (robust to pad_id == eos_id)
         if pad_len > 0:
             labels[-pad_len:] = -100
 
@@ -327,7 +356,6 @@ class HelixDatasetFromTokens(Dataset):
         self.seq_len = seq_len
         self.stride = stride or max(1, seq_len // 2)
 
-        # Pre-compute indices for all valid chunks
         n = len(self.tokens)
         self.indices = list(range(0, max(1, n - seq_len), self.stride))
         if n >= seq_len and (n - seq_len) % self.stride != 0:
@@ -352,20 +380,7 @@ class HelixDatasetFromTokens(Dataset):
 class HelixHFDataset(Dataset):
     """
     Wrapper for HuggingFace datasets with streaming and non-streaming support.
-    Handles text > seq_len via rolling chunking. Works with both Dataset
-    and IterableDataset sources.
-
-    Args:
-        hf_dataset: A HuggingFace datasets.Dataset or IterableDataset,
-                    or a dataset name string.
-        tokenizer: Tokenizer instance.
-        seq_len: Target sequence length.
-        text_column: Column name containing text.
-        stride: Rolling window stride.
-        max_samples: Maximum number of samples to use. For streaming datasets,
-                     uses .take(); for map datasets, uses .select().
-        lazy: Whether to build chunks lazily.
-        **kwargs: Additional arguments passed to load_dataset if hf_dataset is a string.
+    Uses DocumentAwareDataset internally, so no cross-document boundaries.
     """
     def __init__(
         self,
@@ -381,7 +396,6 @@ class HelixHFDataset(Dataset):
         super().__init__()
         self.tokenizer = tokenizer
         self.seq_len = seq_len
-        self.stride = stride or max(1, seq_len // 2)
         self.text_column = text_column
         self.lazy = lazy
         self.max_samples = max_samples
@@ -389,7 +403,6 @@ class HelixHFDataset(Dataset):
         if isinstance(hf_dataset, str):
             from datasets import load_dataset
             dataset_name = hf_dataset
-            # Only pass trust_remote_code for known script-based datasets
             known_script_datasets = {"openai_humaneval", "bigcode/the-stack", "bigcode/the-stack-v2"}
             load_kwargs = dict(kwargs)
             if dataset_name not in known_script_datasets:
@@ -398,27 +411,21 @@ class HelixHFDataset(Dataset):
         else:
             self.dataset = hf_dataset
 
-        # Handle DatasetDict: use "train" split by default
         if hasattr(self.dataset, "keys") and hasattr(self.dataset, "__getitem__"):
             if "train" in self.dataset:
                 self.dataset = self.dataset["train"]
             else:
-                # Pick first available split
                 self.dataset = self.dataset[list(self.dataset.keys())[0]]
 
-        # Apply max_samples
         if max_samples is not None:
             if hasattr(self.dataset, "take") and hasattr(self.dataset, "__iter__"):
-                # IterableDataset
                 self.dataset = self.dataset.take(max_samples)
             elif hasattr(self.dataset, "select"):
-                # Map Dataset
                 indices = list(range(min(max_samples, len(self.dataset))))
                 self.dataset = self.dataset.select(indices)
 
         # Extract texts
         if hasattr(self.dataset, "__iter__") and not hasattr(self.dataset, "__getitem__"):
-            # IterableDataset: consume to list (streaming)
             self._texts = []
             iterable = tqdm(self.dataset, desc="Loading HF dataset", unit="sample",
                             total=max_samples, disable=max_samples is not None and max_samples < 1000)
@@ -430,7 +437,6 @@ class HelixHFDataset(Dataset):
                     break
             self._dataset_type = "list"
         else:
-            # Map Dataset or list
             if hasattr(self.dataset, "__getitem__") and hasattr(self.dataset, "__len__"):
                 iterable = tqdm(range(len(self.dataset)), desc="Loading HF dataset", unit="sample",
                                 disable=len(self.dataset) < 1000)
@@ -441,10 +447,9 @@ class HelixHFDataset(Dataset):
                 self._texts = list(self.dataset)
                 self._dataset_type = "list"
 
-        # Wrap with DocumentAwareDataset for chunking
         self._doc_dataset = DocumentAwareDataset(
             self._texts, tokenizer, seq_len,
-            min_tail_len=seq_len // 4, add_eos=True, lazy=lazy,
+            min_tail_len=seq_len // 4, add_eos=True, lazy=lazy, stride=stride,
         )
 
     def __len__(self) -> int:
@@ -469,9 +474,6 @@ def create_helix_dataloader(
     lazy: bool = True,
     **kwargs,
 ) -> torch.utils.data.DataLoader:
-    """
-    Create a DataLoader from text list with rolling chunking.
-    """
     dataset = HelixDataset(texts, tokenizer, seq_len, stride, lazy=lazy, **kwargs)
 
     def collate_fn(batch):
@@ -507,29 +509,19 @@ def create_document_loader(
     min_tail_len: Optional[int] = None,
     add_eos: bool = True,
     lazy: bool = True,
+    stride: Optional[int] = None,
 ) -> DataLoader:
     """
     Create a DataLoader using DocumentAwareDataset (no boundary crossings).
 
     Args:
-        texts: List of document texts.
-        tokenizer: Tokenizer instance.
-        seq_len: Sequence length for chunks.
-        batch_size: Batch size.
-        shuffle: Whether to shuffle chunks.
-        drop_last: Whether to drop last incomplete batch.
-        num_workers: DataLoader workers.
-        min_tail_len: Minimum tail length to keep. Default seq_len//4.
-        add_eos: Whether to append EOS to documents.
-        lazy: If True, tokenize on-the-fly. If False, eagerly tokenize.
-
-    Returns:
-        DataLoader yielding batches with input_ids, labels, attention_mask,
-        and is_natural_stop tensors.
+        stride: If < seq_len, enables within-document overlap (default: seq_len).
+                This restores more optimizer steps per epoch without ever
+                crossing document boundaries.
     """
     ds = DocumentAwareDataset(
         texts, tokenizer, seq_len,
-        min_tail_len=min_tail_len, add_eos=add_eos, lazy=lazy,
+        min_tail_len=min_tail_len, add_eos=add_eos, lazy=lazy, stride=stride,
     )
 
     def collate_fn(batch):
@@ -552,3 +544,4 @@ def create_document_loader(
         num_workers=num_workers,
         drop_last=drop_last,
     )
+  

--- a/helix_lm/dataset.py
+++ b/helix_lm/dataset.py
@@ -169,19 +169,14 @@ class HelixDataset(Dataset):
                 labels[-pad_len:] = [-100] * pad_len
             return self._make_sample(chunk, labels, is_natural_stop=True)
 
-    def _make_sample(self, chunk: List[int], labels: List[int], is_natural_stop: bool) -> Dict[str, torch.Tensor]:
-        """Create a sample dictionary from chunk."""
+    def _make_sample(self, chunk, labels, is_natural_stop):
         input_ids = torch.tensor(chunk[:self.seq_len], dtype=torch.long)
-        labels_tensor = torch.tensor(labels[:self.seq_len], dtype=torch.long)
-        labels_tensor = torch.where(
-            labels_tensor == self.tokenizer.pad_token_id,
-            torch.tensor(-100, dtype=torch.long),
-            labels_tensor,
-        )
+        labels_t = torch.tensor(labels[:self.seq_len], dtype=torch.long)
+        # DO NOT blanket-mask pad_token_id here — pad_token_id may equal eos_token_id.
         attention_mask = (input_ids != self.tokenizer.pad_token_id).long()
         return {
             "input_ids": input_ids,
-            "labels": labels_tensor,
+            "labels": labels_t,
             "attention_mask": attention_mask,
             "is_natural_stop": torch.tensor(is_natural_stop, dtype=torch.bool),
         }
@@ -291,7 +286,17 @@ class DocumentAwareDataset(Dataset):
         chunk, is_natural = self.chunks[idx]
         x = torch.tensor(chunk, dtype=torch.long)
         labels = x.clone()
-        labels[x == self.pad_id] = -100
+
+        # Only mask trailing padding we actually appended in _build_chunks
+        pad_len = 0
+        for i in reversed(range(len(chunk))):
+            if chunk[i] == self.pad_id:
+                pad_len += 1
+            else:
+                break
+        if pad_len > 0:
+            labels[-pad_len:] = -100
+
         return {
             "input_ids": x,
             "labels": labels,

--- a/helix_lm/dataset.py
+++ b/helix_lm/dataset.py
@@ -8,17 +8,20 @@ Key features:
   - Supports both raw text and pre-tokenized inputs
   - Compatible with HF datasets streaming interface
   - Document-aware chunking: no cross-document boundaries, 100% token utilization
+  - Optional lazy loading: O(1) init, tokenize on-the-fly
 """
 import random
 from typing import List, Optional, Iterator, Dict, Any, Union, Tuple
 
 import torch
 from torch.utils.data import IterableDataset, Dataset, DataLoader
+from tqdm import tqdm
 
 
-class HelixDataset(IterableDataset):
+class HelixDataset(Dataset):
     """
-    Streaming dataset with rolling chunking for language model pretraining.
+    Index-based Dataset with rolling chunking for language model pretraining.
+    Compatible with DataLoader(shuffle=True) natively.
 
     Handles three scenarios:
       1. Text >> seq_len: rolling window with configurable stride
@@ -30,6 +33,16 @@ class HelixDataset(IterableDataset):
       - labels: (seq_len,) — shifted by 1 for next-token prediction
       - attention_mask: (seq_len,) — 1 for real tokens, 0 for padding
       - is_natural_stop: scalar bool — True if chunk ends at document boundary
+
+    Args:
+        texts: List of document texts.
+        tokenizer: Tokenizer instance.
+        seq_len: Target sequence length.
+        stride: Rolling window stride. Default: seq_len // 2.
+        lazy: If True, store raw texts and tokenize on-the-fly in __getitem__.
+              If False, eagerly tokenize all documents in __init__.
+        add_eos: Whether to append EOS token to each document.
+        natural_stop_threshold: Fraction of document length to consider as natural stop.
     """
     def __init__(
         self,
@@ -37,8 +50,7 @@ class HelixDataset(IterableDataset):
         tokenizer,
         seq_len: int = 2048,
         stride: Optional[int] = None,
-        shuffle: bool = True,
-        drop_last: bool = True,
+        lazy: bool = True,
         add_eos: bool = True,
         natural_stop_threshold: float = 0.8,
     ):
@@ -46,105 +58,127 @@ class HelixDataset(IterableDataset):
         self.texts = texts
         self.tokenizer = tokenizer
         self.seq_len = seq_len
-        self.stride = stride or max(1, seq_len // 2)  # Default 50% overlap
-        self.shuffle = shuffle
-        self.drop_last = drop_last
+        self.stride = stride or max(1, seq_len // 2)
+        self.lazy = lazy
         self.add_eos = add_eos
         self.natural_stop_threshold = natural_stop_threshold
 
-        # Pre-tokenize all texts
-        self._tokenized_docs = self._tokenize_all()
+        if lazy:
+            # O(1) init: just store texts
+            self._tokenized_docs = None
+            self._chunk_index = None
+        else:
+            # Eager tokenization with progress bar
+            self._tokenized_docs = self._tokenize_all()
+            self._chunk_index = self._build_chunk_index()
 
     def _tokenize_all(self) -> List[Dict[str, Any]]:
         """Pre-tokenize all documents, storing per-document token lists."""
         docs = []
-        for text in self.texts:
+        iterable = tqdm(self.texts, desc="Tokenizing", unit="doc", disable=len(self.texts) < 1000)
+        for text in iterable:
             if not text.strip():
                 continue
             ids = self.tokenizer.encode(text, add_special_tokens=False)
             if self.add_eos and hasattr(self.tokenizer, 'eos_token_id'):
                 ids.append(self.tokenizer.eos_token_id)
-            docs.append({
-                "ids": ids,
-                "length": len(ids),
-            })
+            docs.append({"ids": ids, "length": len(ids)})
         return docs
 
-    def __len__(self) -> int:
-        """Approximate number of samples (for progress bars)."""
-        total = 0
-        for doc in self._tokenized_docs:
+    def _build_chunk_index(self) -> List[Tuple[int, int, bool]]:
+        """Build (doc_idx, start_idx, is_natural_stop) for every chunk."""
+        index = []
+        for doc_idx, doc in enumerate(self._tokenized_docs):
             length = doc["length"]
-            if length >= self.seq_len:
-                total += (length - self.seq_len) // self.stride + 1
-            else:
-                total += 1
-        return total
-
-    def __iter__(self) -> Iterator[Dict[str, torch.Tensor]]:
-        """Yield samples with rolling chunking."""
-        worker_info = torch.utils.data.get_worker_info()
-        docs = self._tokenized_docs
-
-        if worker_info is not None:
-            per_worker = len(docs) // worker_info.num_workers
-            worker_id = worker_info.id
-            start = worker_id * per_worker
-            end = start + per_worker if worker_id < worker_info.num_workers - 1 else len(docs)
-            docs = docs[start:end]
-
-        if self.shuffle:
-            random.shuffle(docs)
-
-        for doc in docs:
-            ids = doc["ids"]
-            length = doc["length"]
-
             if length == 0:
                 continue
-
+            ids = doc["ids"]
             if length >= self.seq_len:
-                # Rolling window: yield overlapping chunks
                 for start_idx in range(0, length - self.seq_len + 1, self.stride):
                     end_idx = start_idx + self.seq_len
-                    chunk = ids[start_idx:end_idx]
-                    labels = list(chunk)   # unshifted; HF model handles causal shift
-                    # Sliding-window masking: predictions for overlap tokens are
-                    # evaluated in the previous window; mask them with -100.
-                    if start_idx > 0 and self.stride < self.seq_len:
-                        warmup_len = self.seq_len - self.stride
-                        labels[:warmup_len] = [-100] * warmup_len
-
-                    # Natural stop: is this the last chunk of this document?
                     is_natural_stop = end_idx >= length * self.natural_stop_threshold
-
-                    yield self._make_sample(chunk, labels, is_natural_stop)
-
+                    index.append((doc_idx, start_idx, is_natural_stop))
                     if end_idx >= length:
                         break
             else:
-                # Short document: pad to seq_len
-                chunk = ids[:length]
-                pad_len = self.seq_len - length
-                chunk = chunk + [self.tokenizer.pad_token_id] * pad_len
-                labels = list(chunk)
-                if pad_len > 0:
-                    labels[-pad_len:] = [-100] * pad_len
+                index.append((doc_idx, 0, True))
+        return index
 
-                yield self._make_sample(chunk, labels, is_natural_stop=True)
+    def _build_lazy_chunk_index(self) -> List[Tuple[int, int, int, bool]]:
+        """Build chunk index from raw texts on-the-fly.
+        Returns (doc_idx, start_idx, effective_len, is_natural_stop).
+        """
+        index = []
+        for doc_idx, text in enumerate(self.texts):
+            text = text.strip()
+            if not text:
+                continue
+            ids = self.tokenizer.encode(text, add_special_tokens=False)
+            if self.add_eos and hasattr(self.tokenizer, 'eos_token_id'):
+                ids.append(self.tokenizer.eos_token_id)
+            length = len(ids)
+            if length == 0:
+                continue
+            if length >= self.seq_len:
+                for start_idx in range(0, length - self.seq_len + 1, self.stride):
+                    end_idx = start_idx + self.seq_len
+                    is_natural_stop = end_idx >= length * self.natural_stop_threshold
+                    index.append((doc_idx, start_idx, length, is_natural_stop))
+                    if end_idx >= length:
+                        break
+            else:
+                index.append((doc_idx, 0, length, True))
+        return index
+
+    def __len__(self) -> int:
+        if self._chunk_index is not None:
+            return len(self._chunk_index)
+        # Lazy mode: build index on first len() call and cache it
+        if not hasattr(self, '_lazy_index') or self._lazy_index is None:
+            self._lazy_index = self._build_lazy_chunk_index()
+        return len(self._lazy_index)
+
+    def __getitem__(self, idx: int) -> Dict[str, torch.Tensor]:
+        if self._chunk_index is not None:
+            doc_idx, start_idx, is_natural_stop = self._chunk_index[idx]
+            ids = self._tokenized_docs[doc_idx]["ids"]
+            length = self._tokenized_docs[doc_idx]["length"]
+        else:
+            if not hasattr(self, '_lazy_index') or self._lazy_index is None:
+                self._lazy_index = self._build_lazy_chunk_index()
+            doc_idx, start_idx, length, is_natural_stop = self._lazy_index[idx]
+            text = self.texts[doc_idx].strip()
+            ids = self.tokenizer.encode(text, add_special_tokens=False)
+            if self.add_eos and hasattr(self.tokenizer, 'eos_token_id'):
+                ids.append(self.tokenizer.eos_token_id)
+
+        if length >= self.seq_len:
+            end_idx = start_idx + self.seq_len
+            chunk = ids[start_idx:end_idx]
+            labels = list(chunk)
+            if start_idx > 0 and self.stride < self.seq_len:
+                warmup_len = self.seq_len - self.stride
+                labels[:warmup_len] = [-100] * warmup_len
+            return self._make_sample(chunk, labels, is_natural_stop)
+        else:
+            chunk = ids[:length]
+            pad_len = self.seq_len - length
+            chunk = chunk + [self.tokenizer.pad_token_id] * pad_len
+            labels = list(chunk)
+            if pad_len > 0:
+                labels[-pad_len:] = [-100] * pad_len
+            return self._make_sample(chunk, labels, is_natural_stop=True)
 
     def _make_sample(self, chunk: List[int], labels: List[int], is_natural_stop: bool) -> Dict[str, torch.Tensor]:
         """Create a sample dictionary from chunk."""
         input_ids = torch.tensor(chunk[:self.seq_len], dtype=torch.long)
         labels_tensor = torch.tensor(labels[:self.seq_len], dtype=torch.long)
-        # Convert any remaining pad tokens to -100 so CrossEntropyLoss ignores them
         labels_tensor = torch.where(
             labels_tensor == self.tokenizer.pad_token_id,
             torch.tensor(-100, dtype=torch.long),
             labels_tensor,
         )
         attention_mask = (input_ids != self.tokenizer.pad_token_id).long()
-
         return {
             "input_ids": input_ids,
             "labels": labels_tensor,
@@ -164,71 +198,96 @@ class DocumentAwareDataset(Dataset):
       - Only padding positions are masked in labels (-100).
       - No label masking for overlap regions (100% token utilization).
 
-    This eliminates the "islands of good PPL in a sea of bad PPL" problem
-    caused by document-boundary crossings in contiguous-stream chunking.
-
     Args:
         texts: List of document texts.
         tokenizer: Tokenizer with encode(), pad_token_id, eos_token_id.
         seq_len: Target sequence length for all chunks.
         min_tail_len: Minimum length for a tail chunk to be kept.
-                      Tails shorter than this are dropped.
-                      Default: seq_len // 4 (drop very short tails).
+                      Default: seq_len // 4.
                       Set to 1 to keep all tails (e.g., for instruct data).
         add_eos: Whether to append EOS token to each document.
+        lazy: If True, store raw texts and build chunks on-the-fly.
+              If False, eagerly tokenize all documents in __init__.
     """
-    def __init__(self, texts, tokenizer, seq_len, min_tail_len=None, add_eos=True):
+    def __init__(self, texts, tokenizer, seq_len, min_tail_len=None, add_eos=True, lazy=True):
         self.seq_len = seq_len
+        self.tokenizer = tokenizer
         self.pad_id = getattr(tokenizer, "pad_token_id", 0)
         self.eos_id = getattr(tokenizer, "eos_token_id", self.pad_id)
-        self.chunks = []
+        self.lazy = lazy
 
         if min_tail_len is None:
             min_tail_len = seq_len // 4
+        self.min_tail_len = min_tail_len
+        self.add_eos = add_eos
 
+        if lazy:
+            self.texts = texts
+            self.chunks = None
+            self._stats = None
+        else:
+            self.texts = None
+            self.chunks, self._stats = self._build_chunks(texts)
+
+    def _build_chunks(self, texts):
+        """Eagerly build chunks from texts. Returns (chunks, stats)."""
+        chunks = []
         dropped_short = 0
         dropped_tail = 0
         kept = 0
 
-        for text in texts:
+        iterable = tqdm(texts, desc="Chunking", unit="doc", disable=len(texts) < 1000)
+        for text in iterable:
             text = text.strip()
             if not text:
                 continue
 
-            ids = tokenizer.encode(text, add_special_tokens=False)
-            if len(ids) < min_tail_len:
+            ids = self.tokenizer.encode(text, add_special_tokens=False)
+            if len(ids) < self.min_tail_len:
                 dropped_short += 1
                 continue
 
-            if add_eos and self.eos_id is not None:
+            if self.add_eos and self.eos_id is not None:
                 ids.append(self.eos_id)
 
-            n_full = len(ids) // seq_len
-            remainder_len = len(ids) % seq_len
+            n_full = len(ids) // self.seq_len
+            remainder_len = len(ids) % self.seq_len
 
             for i in range(n_full):
-                start = i * seq_len
-                chunk = ids[start:start + seq_len]
+                start = i * self.seq_len
+                chunk = ids[start:start + self.seq_len]
                 is_last_chunk = (i == n_full - 1)
-                no_tail_kept = (remainder_len < min_tail_len)
-                self.chunks.append((chunk, is_last_chunk and no_tail_kept))
+                no_tail_kept = (remainder_len < self.min_tail_len)
+                chunks.append((chunk, is_last_chunk and no_tail_kept))
                 kept += 1
 
-            if remainder_len >= min_tail_len:
-                tail = ids[n_full * seq_len:]
-                tail = tail + [self.pad_id] * (seq_len - remainder_len)
-                self.chunks.append((tail, True))
+            if remainder_len >= self.min_tail_len:
+                tail = ids[n_full * self.seq_len:]
+                tail = tail + [self.pad_id] * (self.seq_len - remainder_len)
+                chunks.append((tail, True))
                 kept += 1
             elif remainder_len > 0:
                 dropped_tail += 1
 
-        print(f"DocumentAwareDataset: {kept} chunks "
-              f"({dropped_short} short docs dropped, {dropped_tail} tails dropped)")
+        stats = {
+            "kept": kept,
+            "dropped_short": dropped_short,
+            "dropped_tail": dropped_tail,
+        }
+        return chunks, stats
+
+    def _ensure_chunks(self):
+        """Lazy build chunks on first access."""
+        if self.chunks is None:
+            self.chunks, self._stats = self._build_chunks(self.texts)
+            self.texts = None  # free memory
 
     def __len__(self):
+        self._ensure_chunks()
         return len(self.chunks)
 
     def __getitem__(self, idx):
+        self._ensure_chunks()
         chunk, is_natural = self.chunks[idx]
         x = torch.tensor(chunk, dtype=torch.long)
         labels = x.clone()
@@ -239,6 +298,10 @@ class DocumentAwareDataset(Dataset):
             "attention_mask": (x != self.pad_id).long(),
             "is_natural_stop": torch.tensor(is_natural, dtype=torch.bool),
         }
+
+    def get_stats(self):
+        self._ensure_chunks()
+        return self._stats
 
 
 class HelixDatasetFromTokens(Dataset):
@@ -272,8 +335,7 @@ class HelixDatasetFromTokens(Dataset):
         start = self.indices[idx]
         end = start + self.seq_len
         x = self.tokens[start:end]
-        y = x.clone()   # unshifted for HF causal-LM shift
-
+        y = x.clone()
         return {
             "input_ids": x,
             "labels": y,
@@ -282,21 +344,33 @@ class HelixDatasetFromTokens(Dataset):
         }
 
 
-class HelixHFDataset(IterableDataset):
+class HelixHFDataset(Dataset):
     """
-    Wrapper for HuggingFace datasets with streaming support.
-    Handles text > seq_len via rolling chunking.
+    Wrapper for HuggingFace datasets with streaming and non-streaming support.
+    Handles text > seq_len via rolling chunking. Works with both Dataset
+    and IterableDataset sources.
+
+    Args:
+        hf_dataset: A HuggingFace datasets.Dataset or IterableDataset,
+                    or a dataset name string.
+        tokenizer: Tokenizer instance.
+        seq_len: Target sequence length.
+        text_column: Column name containing text.
+        stride: Rolling window stride.
+        max_samples: Maximum number of samples to use. For streaming datasets,
+                     uses .take(); for map datasets, uses .select().
+        lazy: Whether to build chunks lazily.
+        **kwargs: Additional arguments passed to load_dataset if hf_dataset is a string.
     """
     def __init__(
         self,
-        dataset_name: str,
+        hf_dataset: Union[str, Any],
         tokenizer,
         seq_len: int = 2048,
         text_column: str = "text",
-        split: str = "train",
-        streaming: bool = True,
         stride: Optional[int] = None,
-        shuffle_buffer_size: int = 10000,
+        max_samples: Optional[int] = None,
+        lazy: bool = True,
         **kwargs,
     ):
         super().__init__()
@@ -304,40 +378,78 @@ class HelixHFDataset(IterableDataset):
         self.seq_len = seq_len
         self.stride = stride or max(1, seq_len // 2)
         self.text_column = text_column
+        self.lazy = lazy
+        self.max_samples = max_samples
 
-        try:
+        if isinstance(hf_dataset, str):
             from datasets import load_dataset
-            self.dataset = load_dataset(dataset_name, split=split, streaming=streaming, **kwargs)
-            if streaming:
-                self.dataset = self.dataset.shuffle(seed=42, buffer_size=shuffle_buffer_size)
-        except ImportError:
-            raise ImportError("Please install `datasets` library: pip install datasets")
+            dataset_name = hf_dataset
+            # Only pass trust_remote_code for known script-based datasets
+            known_script_datasets = {"openai_humaneval", "bigcode/the-stack", "bigcode/the-stack-v2"}
+            load_kwargs = dict(kwargs)
+            if dataset_name not in known_script_datasets:
+                load_kwargs.pop("trust_remote_code", None)
+            self.dataset = load_dataset(dataset_name, **load_kwargs)
+        else:
+            self.dataset = hf_dataset
 
-    def __iter__(self) -> Iterator[Dict[str, torch.Tensor]]:
-        buffer = []
-        buffer_text = ""
+        # Handle DatasetDict: use "train" split by default
+        if hasattr(self.dataset, "keys") and hasattr(self.dataset, "__getitem__"):
+            if "train" in self.dataset:
+                self.dataset = self.dataset["train"]
+            else:
+                # Pick first available split
+                self.dataset = self.dataset[list(self.dataset.keys())[0]]
 
-        for example in self.dataset:
-            text = example.get(self.text_column, "")
-            if not text:
-                continue
+        # Apply max_samples
+        if max_samples is not None:
+            if hasattr(self.dataset, "take") and hasattr(self.dataset, "__iter__"):
+                # IterableDataset
+                self.dataset = self.dataset.take(max_samples)
+            elif hasattr(self.dataset, "select"):
+                # Map Dataset
+                indices = list(range(min(max_samples, len(self.dataset))))
+                self.dataset = self.dataset.select(indices)
 
-            ids = self.tokenizer.encode(text, add_special_tokens=False)
-            if hasattr(self.tokenizer, 'eos_token_id'):
-                ids.append(self.tokenizer.eos_token_id)
+        # Extract texts
+        if hasattr(self.dataset, "__iter__") and not hasattr(self.dataset, "__getitem__"):
+            # IterableDataset: consume to list (streaming)
+            self._texts = []
+            iterable = tqdm(self.dataset, desc="Loading HF dataset", unit="sample",
+                            total=max_samples, disable=max_samples is not None and max_samples < 1000)
+            for example in iterable:
+                text = example.get(self.text_column, "")
+                if text:
+                    self._texts.append(text)
+                if max_samples is not None and len(self._texts) >= max_samples:
+                    break
+            self._dataset_type = "list"
+        else:
+            # Map Dataset or list
+            if hasattr(self.dataset, "__getitem__") and hasattr(self.dataset, "__len__"):
+                iterable = tqdm(range(len(self.dataset)), desc="Loading HF dataset", unit="sample",
+                                disable=len(self.dataset) < 1000)
+                self._texts = [self.dataset[i].get(self.text_column, "") for i in iterable]
+                self._texts = [t for t in self._texts if t]
+                self._dataset_type = "map"
+            else:
+                self._texts = list(self.dataset)
+                self._dataset_type = "list"
 
-            buffer.extend(ids)
+        # Wrap with DocumentAwareDataset for chunking
+        self._doc_dataset = DocumentAwareDataset(
+            self._texts, tokenizer, seq_len,
+            min_tail_len=seq_len // 4, add_eos=True, lazy=lazy,
+        )
 
-            # Yield complete sequences from buffer
-            while len(buffer) >= self.seq_len + 1:
-                x = torch.tensor(buffer[:self.seq_len], dtype=torch.long)
-                y = x.clone()   # unshifted; HF model handles causal shift
-                yield {
-                    "input_ids": x,
-                    "labels": y,
-                    "attention_mask": torch.ones(self.seq_len, dtype=torch.long),
-                    "is_natural_stop": torch.tensor(False, dtype=torch.bool),
-                }
+    def __len__(self) -> int:
+        return len(self._doc_dataset)
+
+    def __getitem__(self, idx: int) -> Dict[str, torch.Tensor]:
+        return self._doc_dataset[idx]
+
+    def get_stats(self):
+        return self._doc_dataset.get_stats()
 
 
 def create_helix_dataloader(
@@ -349,12 +461,13 @@ def create_helix_dataloader(
     shuffle: bool = True,
     num_workers: int = 0,
     drop_last: bool = True,
+    lazy: bool = True,
     **kwargs,
 ) -> torch.utils.data.DataLoader:
     """
     Create a DataLoader from text list with rolling chunking.
     """
-    dataset = HelixDataset(texts, tokenizer, seq_len, stride, shuffle, drop_last, **kwargs)
+    dataset = HelixDataset(texts, tokenizer, seq_len, stride, lazy=lazy, **kwargs)
 
     def collate_fn(batch):
         input_ids = torch.stack([b["input_ids"] for b in batch])
@@ -372,6 +485,7 @@ def create_helix_dataloader(
         dataset,
         batch_size=batch_size,
         collate_fn=collate_fn,
+        shuffle=shuffle,
         num_workers=num_workers,
         drop_last=drop_last,
     )
@@ -387,6 +501,7 @@ def create_document_loader(
     num_workers: int = 0,
     min_tail_len: Optional[int] = None,
     add_eos: bool = True,
+    lazy: bool = True,
 ) -> DataLoader:
     """
     Create a DataLoader using DocumentAwareDataset (no boundary crossings).
@@ -400,8 +515,8 @@ def create_document_loader(
         drop_last: Whether to drop last incomplete batch.
         num_workers: DataLoader workers.
         min_tail_len: Minimum tail length to keep. Default seq_len//4.
-                      Use seq_len//4 for pretrain, 1 for instruct.
         add_eos: Whether to append EOS to documents.
+        lazy: If True, tokenize on-the-fly. If False, eagerly tokenize.
 
     Returns:
         DataLoader yielding batches with input_ids, labels, attention_mask,
@@ -409,7 +524,7 @@ def create_document_loader(
     """
     ds = DocumentAwareDataset(
         texts, tokenizer, seq_len,
-        min_tail_len=min_tail_len, add_eos=add_eos,
+        min_tail_len=min_tail_len, add_eos=add_eos, lazy=lazy,
     )
 
     def collate_fn(batch):

--- a/helix_lm/hf_model.py
+++ b/helix_lm/hf_model.py
@@ -6,6 +6,7 @@ Provides full compatibility with the transformers ecosystem:
   - KV-cache generation beyond max_seq_len
   - Batched generation with stop token / stop string detection
   - save_pretrained / from_pretrained / push_to_hub
+  - Automatic device placement when config.device="auto"
 """
 import math
 from typing import Optional, List, Dict, Any, Tuple, Union
@@ -101,6 +102,23 @@ class HelixPreTrainedModel(PreTrainedModel):
         """Override to return empty dict — we handle weight tying manually."""
         return {}
 
+    def to_device(self, device: Optional[Union[str, torch.device]] = None) -> "HelixPreTrainedModel":
+        """Move model to the specified device, or auto-detect if None."""
+        if device is None:
+            device = self._resolve_device()
+        return self.to(device)
+
+    def _resolve_device(self) -> torch.device:
+        """Resolve device from config or auto-detect."""
+        cfg_device = getattr(self.config, "device", "auto")
+        if cfg_device == "auto":
+            if torch.cuda.is_available():
+                return torch.device("cuda")
+            elif torch.backends.mps.is_available():
+                return torch.device("mps")
+            return torch.device("cpu")
+        return torch.device(cfg_device)
+
 
 class HelixForCausalLM(HelixPreTrainedModel, GenerationMixin):
     """
@@ -117,6 +135,19 @@ class HelixForCausalLM(HelixPreTrainedModel, GenerationMixin):
 
         # KV cache for generation
         self._kv_cache: Optional[HelixKVCache] = None
+
+        # Auto device placement
+        target_device = self._resolve_device()
+        if target_device.type == "cpu" and torch.cuda.is_available():
+            import warnings
+            warnings.warn(
+                f"HelixConfig.device='{getattr(config, 'device', 'auto')}' resolved to CPU, "
+                f"but CUDA is available. Model will run on CPU. "
+                f"Call model.to('cuda') or set config.device='cuda' to use GPU.",
+                UserWarning,
+                stacklevel=2,
+            )
+        self.to(target_device)
 
     def get_input_embeddings(self) -> nn.Embedding:
         return self.model.embed

--- a/helix_lm/hf_model.py
+++ b/helix_lm/hf_model.py
@@ -127,7 +127,9 @@ class HelixForCausalLM(HelixPreTrainedModel, GenerationMixin):
     def __init__(self, config: HelixConfig):
         super().__init__(config)
         self.config = config
-        self.model = HelixLMCore(config, tie_weights=False)
+        # FIX: Pass create_output_head=False to avoid dead-weight duplicate head.
+        # HelixForCausalLM owns the sole lm_head used in forward().
+        self.model = HelixLMCore(config, tie_weights=False, create_output_head=False)
         self.lm_head = nn.Linear(config.d_model, config.vocab_size, bias=False)
 
         # Initialize weights
@@ -285,7 +287,7 @@ class HelixForCausalLM(HelixPreTrainedModel, GenerationMixin):
             # Top-k
             if top_k is not None:
                 v, _ = torch.topk(logits, min(top_k, logits.size(-1)))
-                logits[logits < v[:, [-1]]] = float('-inf')
+                logits[logits < v[:, [-1]]] = float("-inf")
 
             # Top-p
             if top_p is not None:
@@ -295,7 +297,7 @@ class HelixForCausalLM(HelixPreTrainedModel, GenerationMixin):
                 sorted_indices_to_remove[..., 1:] = sorted_indices_to_remove[..., :-1].clone()
                 sorted_indices_to_remove[..., 0] = False
                 indices_to_remove = sorted_indices_to_remove.scatter(-1, sorted_indices, sorted_indices_to_remove)
-                logits[indices_to_remove] = float('-inf')
+                logits[indices_to_remove] = float("-inf")
 
             # Sample
             probs = F.softmax(logits, dim=-1)

--- a/helix_lm/hf_model.py
+++ b/helix_lm/hf_model.py
@@ -194,12 +194,13 @@ class HelixForCausalLM(HelixPreTrainedModel, GenerationMixin):
 
         loss = None
         if labels is not None:
-            # Shift for next-token prediction
-            shift_logits = logits[..., :-1, :].contiguous()
-            shift_labels = labels[..., 1:].contiguous()
-            # CRITICAL: use -100 to support sliding-window warmup masking
+            shift_logits = logits[:, :-1, :].reshape(-1, self.config.vocab_size)
+            shift_labels = labels[:, 1:].reshape(-1)
+            if getattr(self.config, "memory_efficient_forward", False):
+                del logits
+                logits = None
             loss_fct = nn.CrossEntropyLoss(ignore_index=-100)
-            loss = loss_fct(shift_logits.view(-1, self.config.vocab_size), shift_labels.view(-1))
+            loss = loss_fct(shift_logits, shift_labels)
 
         if not return_dict:
             output = (logits,)

--- a/helix_lm/model.py
+++ b/helix_lm/model.py
@@ -37,11 +37,16 @@ class HelixLMCore(nn.Module):
         # RoPE frequencies
         self.register_buffer("freqs_cis", None, persistent=False)
         if cfg.use_rope:
+            # Defensive: cfg.dtype may be mutated to a string after save_pretrained
+            dtype = cfg.dtype
+            if isinstance(dtype, str):
+                dtype = getattr(torch, dtype.replace("torch.", ""))
+
             freqs = precompute_freqs_cis(
                 cfg.head_dim,
                 cfg.seq_len * 4,
                 cfg.rope_theta,
-                dtype=cfg.dtype,
+                dtype=dtype,
             )
             self.register_buffer("freqs_cis", freqs, persistent=False)
 

--- a/helix_lm/model.py
+++ b/helix_lm/model.py
@@ -17,19 +17,22 @@ from .nodes import RMSNorm
 class HelixLMCore(nn.Module):
     """
     Core HelixLM model (non-HF wrapper).
-    
+
     Used internally; for HF compatibility see hf_model.py HelixForCausalLM.
     """
-    def __init__(self, cfg: HelixConfig, tie_weights: bool = True):
+    def __init__(self, cfg: HelixConfig, tie_weights: bool = True, create_output_head: bool = True):
         super().__init__()
         self.cfg = cfg
 
         self.embed = nn.Embedding(cfg.vocab_size, cfg.d_model)
         self.recurrent = HelixRecurrentBlock(cfg)
         self.out_norm = RMSNorm(cfg.d_model)
-        self.head = nn.Linear(cfg.d_model, cfg.vocab_size, bias=False)
-        if tie_weights:
-            self.head.weight = self.embed.weight  # weight tying
+
+        self.head = None
+        if create_output_head:
+            self.head = nn.Linear(cfg.d_model, cfg.vocab_size, bias=False)
+            if tie_weights:
+                self.head.weight = self.embed.weight  # weight tying
 
         # RoPE frequencies
         self.register_buffer("freqs_cis", None, persistent=False)
@@ -55,7 +58,15 @@ class HelixLMCore(nn.Module):
     def forward(self, token_ids: torch.Tensor) -> torch.Tensor:
         e = self.embed(token_ids)
         h = self.recurrent(e, e.detach())
-        logits = self.head(self.out_norm(h))
+        if self.head is not None:
+            logits = self.head(self.out_norm(h))
+        else:
+            raise RuntimeError(
+                "HelixLMCore was created with create_output_head=False, "
+                "but forward() was called without an output head. "
+                "Either create the core with create_output_head=True (default), "
+                "or ensure the caller provides its own output projection."
+            )
         return logits
 
     @torch.no_grad()

--- a/helix_lm/rope.py
+++ b/helix_lm/rope.py
@@ -7,13 +7,26 @@ import torch
 import torch.nn as nn
 
 
-def precompute_freqs_cis(dim: int, end: int, theta: float = 10000.0, dtype: torch.dtype = torch.float32) -> torch.Tensor:
+def precompute_freqs_cis(
+    dim: int,
+    end: int,
+    theta: float = 10000.0,
+    dtype=None,
+) -> torch.Tensor:
     """Precompute RoPE frequency tensor [cos, sin] pairs."""
+    # Defensive: accept string, torch.dtype, or None
+    if dtype is None:
+        torch_dtype = torch.float32
+    elif isinstance(dtype, str):
+        torch_dtype = getattr(torch, dtype.replace("torch.", ""))
+    else:
+        torch_dtype = dtype
+
     freqs = 1.0 / (theta ** (torch.arange(0, dim, 2, dtype=torch.float32)[: (dim // 2)] / dim))
     t = torch.arange(end, dtype=torch.float32)
     freqs = torch.outer(t, freqs)
-    cos = torch.cos(freqs).to(dtype)
-    sin = torch.sin(freqs).to(dtype)
+    cos = torch.cos(freqs).to(torch_dtype)
+    sin = torch.sin(freqs).to(torch_dtype)
     return torch.stack([cos, sin], dim=-1)
 
 

--- a/helix_lm/smoke_test.py
+++ b/helix_lm/smoke_test.py
@@ -104,6 +104,7 @@ def main():
         epochs=30,
         grad_clip=1.0,
         tokenizer_name="char",
+        use_titans_memory=False,
     )
 
     # Load data

--- a/helix_lm/tokenizer.py
+++ b/helix_lm/tokenizer.py
@@ -237,3 +237,10 @@ class HelixTokenizer:
         if return_dict:
             return result
         return result["input_ids"]
+
+    def save_pretrained(self, path):
+        return self._backend.save_pretrained(path)
+
+    def push_to_hub(self, repo_id, **kwargs):
+        return self._backend.push_to_hub(repo_id, **kwargs)
+

--- a/helix_lm/trainer.py
+++ b/helix_lm/trainer.py
@@ -265,6 +265,7 @@ class Trainer:
                 continue
 
             # Scale loss for gradient accumulation
+            divisor = 1
             if self.grad_accum_steps > 1:
                 is_last = (batch_idx + 1) == len(self.train_loader)
                 if is_last and accum_count < self.grad_accum_steps - 1:
@@ -280,7 +281,7 @@ class Trainer:
                 loss.backward()
 
             accum_count += 1
-            total_loss += loss.item() * max(1, self.grad_accum_steps)
+            total_loss += loss.item() * divisor
             raw_count += 1
 
             # Optimizer step after accumulation
@@ -470,3 +471,4 @@ class Trainer:
         if self.verbose:
             print(f"\nTraining complete!")
         return self.history
+

--- a/helix_lm/trainer.py
+++ b/helix_lm/trainer.py
@@ -1,5 +1,5 @@
 """
-HelixLM Trainer with gradient accumulation and configurable AMP.
+HelixLM Trainer with gradient accumulation, configurable AMP, and progress bars.
 
 Key features:
   - Gradient accumulation for effective larger batch sizes
@@ -8,10 +8,13 @@ Key features:
   - Scheduler steps count optimizer steps, not raw batches
   - Uses DocumentAwareDataset (no cross-document boundary crossings)
   - Modern torch.amp API (not deprecated torch.cuda.amp)
+  - Live tqdm progress bars with loss, PPL, LR, and throughput metrics
+  - Optional train/val DataLoader injection for custom dataset pipelines
 """
 import os
 import math
 import time
+import warnings
 from typing import Optional, List, Dict, Any
 
 import torch
@@ -19,6 +22,8 @@ import torch.nn as nn
 import torch.nn.functional as F
 from torch.optim import AdamW
 from torch.optim.lr_scheduler import LambdaLR
+from torch.utils.data import DataLoader
+from tqdm import tqdm
 
 from .config import HelixConfig
 from .hf_model import HelixForCausalLM
@@ -62,13 +67,13 @@ def format_time(seconds: float) -> str:
 
 
 class Trainer:
-    """Trainer for HelixLM with gradient accumulation and configurable AMP."""
+    """Trainer for HelixLM with gradient accumulation, AMP, and progress bars."""
 
     def __init__(
         self,
         model: HelixForCausalLM,
         cfg: HelixConfig,
-        train_texts: List[str],
+        train_texts: Optional[List[str]] = None,
         val_texts: Optional[List[str]] = None,
         tokenizer=None,
         output_dir: str = "./checkpoints",
@@ -77,6 +82,9 @@ class Trainer:
         grad_accum_steps: int = 1,
         use_amp: bool = False,
         min_tail_len: Optional[int] = None,
+        train_loader: Optional[DataLoader] = None,
+        val_loader: Optional[DataLoader] = None,
+        verbose: bool = True,
     ):
         """
         Initialize Trainer.
@@ -84,20 +92,18 @@ class Trainer:
         Args:
             model: HelixForCausalLM instance.
             cfg: HelixConfig with training hyperparameters.
-            train_texts: List of training document texts.
-            val_texts: List of validation document texts (optional).
+            train_texts: List of training document texts (used if train_loader not provided).
+            val_texts: List of validation document texts (used if val_loader not provided).
             tokenizer: Tokenizer instance.
             output_dir: Directory to save checkpoints.
             example_prompts: Prompts for generation samples during training.
             generated_example_length: Number of tokens to generate for samples.
             grad_accum_steps: Gradient accumulation steps (default: 1).
-                              Effective batch size = batch_size * grad_accum_steps.
             use_amp: Whether to use torch.amp automatic mixed precision.
-                     Default: False (recommended for models < 100M params).
-                     Enable for XL/XXL on Ampere+ GPUs.
             min_tail_len: Minimum tail length for DocumentAwareDataset.
-                          Default: cfg.seq_len // 4 for pretraining.
-                          Use 1 for instruction tuning.
+            train_loader: Optional custom DataLoader to override built-in dataset creation.
+            val_loader: Optional custom DataLoader to override built-in dataset creation.
+            verbose: Whether to show tqdm progress bars and print logs.
         """
         self.model = model
         self.cfg = cfg
@@ -106,6 +112,7 @@ class Trainer:
         os.makedirs(output_dir, exist_ok=True)
         self.grad_accum_steps = max(1, grad_accum_steps)
         self.use_amp = use_amp and torch.cuda.is_available()
+        self.verbose = verbose
 
         if example_prompts:
             self.example_prompts = example_prompts
@@ -120,17 +127,29 @@ class Trainer:
         self.device = self._get_device()
         self.model = self.model.to(self.device)
 
-        # Use DocumentAwareDataset (no boundary crossings, 100% token utilization)
-        self.train_loader = create_document_loader(
-            train_texts,
-            tokenizer,
-            cfg.seq_len,
-            cfg.batch_size,
-            shuffle=True,
-            min_tail_len=min_tail_len,
-        )
+        # Validate config
+        self.validate_config()
+
+        # Data loaders: use injected loaders if provided, otherwise build from texts
+        if train_loader is not None:
+            self.train_loader = train_loader
+        else:
+            if train_texts is None:
+                raise ValueError("Either train_loader or train_texts must be provided.")
+            self.train_loader = create_document_loader(
+                train_texts,
+                tokenizer,
+                cfg.seq_len,
+                cfg.batch_size,
+                shuffle=True,
+                min_tail_len=min_tail_len,
+                lazy=True,
+            )
+
         self.val_loader = None
-        if val_texts:
+        if val_loader is not None:
+            self.val_loader = val_loader
+        elif val_texts is not None:
             self.val_loader = create_document_loader(
                 val_texts,
                 tokenizer,
@@ -139,9 +158,10 @@ class Trainer:
                 shuffle=False,
                 drop_last=False,
                 min_tail_len=min_tail_len,
+                lazy=True,
             )
 
-        # AdamW with standard betas (0.9, 0.999) — 0.95 is too noisy for small batches
+        # AdamW with standard betas (0.9, 0.999)
         self.optimizer = AdamW(
             model.parameters(),
             lr=cfg.lr,
@@ -169,7 +189,6 @@ class Trainer:
         if self.use_amp:
             try:
                 from torch.amp import GradScaler
-
                 self.scaler = GradScaler("cuda")
             except Exception:
                 self.use_amp = False
@@ -184,20 +203,45 @@ class Trainer:
             return torch.device("cpu")
         return torch.device(self.cfg.device)
 
+    def validate_config(self) -> None:
+        """Validate training config and emit warnings for suboptimal settings."""
+        total_params = getattr(self.model, "count_parameters", lambda: {"total": 0})()["total"]
+        use_titans = getattr(self.cfg, "use_titans_memory", False)
+        seq_len = getattr(self.cfg, "seq_len", 2048)
+
+        if use_titans and total_params < 50_000_000 and seq_len < 512:
+            warnings.warn(
+                f"use_titans_memory=True on a small model ({total_params:,} params) "
+                f"with seq_len={seq_len} may not provide substantial benefit, "
+                f"as Titans state resets per batch at this scale. "
+                f"Consider disabling Titans for faster training or increasing seq_len.",
+                UserWarning,
+                stacklevel=2,
+            )
+
     def train_epoch(self, epoch: int) -> Dict[str, float]:
-        """Train for one epoch with gradient accumulation."""
+        """Train for one epoch with gradient accumulation and progress bar."""
         self.model.train()
         total_loss = 0.0
         raw_count = 0
         accum_count = 0
         skipped_batches = 0
         epoch_start = time.time()
+        tokens_seen = 0
 
         self.optimizer.zero_grad()
 
-        for batch_idx, batch in enumerate(self.train_loader):
+        pbar = tqdm(
+            self.train_loader,
+            desc=f"Epoch {epoch}",
+            unit="batch",
+            disable=not self.verbose,
+        )
+
+        for batch_idx, batch in enumerate(pbar):
             input_ids = batch["input_ids"].to(self.device)
             labels = batch["labels"].to(self.device)
+            tokens_seen += input_ids.numel()
 
             # Forward pass
             if self.use_amp and self.scaler is not None:
@@ -213,7 +257,7 @@ class Trainer:
             # Skip NaN/Inf losses (numerical instability)
             if torch.isnan(loss) or torch.isinf(loss):
                 skipped_batches += 1
-                if skipped_batches <= 5:  # Only warn first few
+                if skipped_batches <= 5 and self.verbose:
                     print(
                         f"  WARNING: NaN/Inf loss at batch {batch_idx}. "
                         f"Skipping. (Try disabling AMP: use_amp=False)"
@@ -222,10 +266,9 @@ class Trainer:
 
             # Scale loss for gradient accumulation
             if self.grad_accum_steps > 1:
-                # If this is the final, incomplete accumulation step, divide by actual count
                 is_last = (batch_idx + 1) == len(self.train_loader)
                 if is_last and accum_count < self.grad_accum_steps - 1:
-                    divisor = accum_count + 1   # +1 because we haven't incremented yet
+                    divisor = accum_count + 1
                 else:
                     divisor = self.grad_accum_steps
                 loss = loss / divisor
@@ -261,15 +304,17 @@ class Trainer:
                 accum_count = 0
                 self.global_step += 1
 
-            # Logging
-            if batch_idx % 10 == 0:
-                lr = self.scheduler.get_last_lr()[0]
-                avg = total_loss / max(raw_count, 1)
-                print(
-                    f"  Batch {batch_idx}/{len(self.train_loader)} | "
-                    f"Loss: {avg:.4f} | PPL: {compute_perplexity(avg):.2f} | "
-                    f"LR: {lr:.2e}"
-                )
+            # Live progress bar update
+            avg = total_loss / max(raw_count, 1)
+            lr = self.scheduler.get_last_lr()[0]
+            elapsed = time.time() - epoch_start
+            tok_per_sec = tokens_seen / max(elapsed, 1e-6)
+            pbar.set_postfix({
+                "loss": f"{avg:.4f}",
+                "ppl": f"{compute_perplexity(avg):.2f}",
+                "lr": f"{lr:.2e}",
+                "tok/s": f"{tok_per_sec:,.0f}",
+            })
 
         avg_loss = total_loss / max(raw_count, 1)
         return {
@@ -281,13 +326,20 @@ class Trainer:
 
     @torch.no_grad()
     def evaluate(self) -> Dict[str, float]:
-        """Evaluate on validation set."""
+        """Evaluate on validation set with progress bar."""
         if self.val_loader is None:
             return {}
         self.model.eval()
         total_loss = 0.0
         num_batches = 0
-        for batch in self.val_loader:
+
+        pbar = tqdm(
+            self.val_loader,
+            desc="Validation",
+            unit="batch",
+            disable=not self.verbose,
+        )
+        for batch in pbar:
             input_ids = batch["input_ids"].to(self.device)
             labels = batch["labels"].to(self.device)
 
@@ -303,6 +355,11 @@ class Trainer:
             if not (torch.isnan(loss) or torch.isinf(loss)):
                 total_loss += loss.item()
                 num_batches += 1
+                avg = total_loss / max(num_batches, 1)
+                pbar.set_postfix({
+                    "loss": f"{avg:.4f}",
+                    "ppl": f"{compute_perplexity(avg):.2f}",
+                })
 
         avg_loss = total_loss / max(num_batches, 1)
         return {"loss": avg_loss, "perplexity": compute_perplexity(avg_loss)}
@@ -335,7 +392,8 @@ class Trainer:
             filename = f"helixlm_epoch_{epoch}.pt"
         path = os.path.join(self.output_dir, filename)
         self.model.save_pretrained(path)
-        print(f"Checkpoint saved to {path}")
+        if self.verbose:
+            print(f"Checkpoint saved to {path}")
 
     def train(
         self, num_epochs: Optional[int] = None, eval_every: int = 1
@@ -344,39 +402,43 @@ class Trainer:
         epochs = num_epochs or self.cfg.epochs
         effective_batch = self.cfg.batch_size * self.grad_accum_steps
 
-        print(f"\n{'='*60}")
-        print(f"Training HelixLM on {self.device}")
-        print(f"Parameters: {self.model.count_parameters()['total']:,}")
-        print(
-            f"Epochs: {epochs} | Batch: {self.cfg.batch_size} | "
-            f"Accum: {self.grad_accum_steps} | Effective: {effective_batch}"
-        )
-        print(f"LR: {self.cfg.lr} | AMP: {self.use_amp}")
-        print(f"{'='*60}\n")
+        if self.verbose:
+            print(f"\n{'='*60}")
+            print(f"Training HelixLM on {self.device}")
+            print(f"Parameters: {self.model.count_parameters()['total']:,}")
+            print(
+                f"Epochs: {epochs} | Batch: {self.cfg.batch_size} | "
+                f"Accum: {self.grad_accum_steps} | Effective: {effective_batch}"
+            )
+            print(f"LR: {self.cfg.lr} | AMP: {self.use_amp}")
+            print(f"{'='*60}\n")
 
         for epoch in range(1, epochs + 1):
-            print(f"\nEpoch {epoch}/{epochs}")
-            print("-" * 40)
+            if self.verbose:
+                print(f"\nEpoch {epoch}/{epochs}")
+                print("-" * 40)
 
             train_metrics = self.train_epoch(epoch)
             skip_info = ""
             if train_metrics.get("skipped_batches", 0) > 0:
                 skip_info = f" | Skipped: {train_metrics['skipped_batches']}"
-            print(
-                f"Train Loss: {train_metrics['loss']:.4f} | "
-                f"PPL: {train_metrics['perplexity']:.2f} | "
-                f"Time: {format_time(train_metrics['time'])}"
-                f"{skip_info}"
-            )
+            if self.verbose:
+                print(
+                    f"Train Loss: {train_metrics['loss']:.4f} | "
+                    f"PPL: {train_metrics['perplexity']:.2f} | "
+                    f"Time: {format_time(train_metrics['time'])}"
+                    f"{skip_info}"
+                )
             self.history["train_loss"].append(train_metrics["loss"])
             self.history["perplexity"].append(train_metrics["perplexity"])
 
             if self.val_loader and epoch % eval_every == 0:
                 val_metrics = self.evaluate()
-                print(
-                    f"Val Loss: {val_metrics['loss']:.4f} | "
-                    f"Val PPL: {val_metrics['perplexity']:.2f}"
-                )
+                if self.verbose:
+                    print(
+                        f"Val Loss: {val_metrics['loss']:.4f} | "
+                        f"Val PPL: {val_metrics['perplexity']:.2f}"
+                    )
                 self.history["val_loss"].append(val_metrics["loss"])
                 if val_metrics["loss"] < self.best_val_loss:
                     self.best_val_loss = val_metrics["loss"]
@@ -385,7 +447,7 @@ class Trainer:
             if epoch % 10 == 0:
                 self.save_checkpoint(epoch)
 
-            if self.tokenizer and epoch % eval_every == 0:
+            if self.tokenizer and epoch % eval_every == 0 and self.verbose:
                 print("\nGeneration samples:")
                 for prompt in self.example_prompts:
                     if self.generated_example_length:
@@ -405,5 +467,6 @@ class Trainer:
                 print()
 
         self.save_checkpoint(epochs, "final_model")
-        print(f"\nTraining complete!")
+        if self.verbose:
+            print(f"\nTraining complete!")
         return self.history

--- a/helix_lm/trainer.py
+++ b/helix_lm/trainer.py
@@ -170,15 +170,12 @@ class Trainer:
         )
 
         # Scheduler steps count optimizer steps, not raw batches
-        steps_per_epoch = math.ceil(
-            len(self.train_loader) / self.grad_accum_steps
-        )
-        total_optimizer_steps = steps_per_epoch * cfg.epochs
-        self.scheduler = get_cosine_schedule_with_warmup(
-            self.optimizer,
-            num_warmup_steps=max(1, cfg.warmup_steps // self.grad_accum_steps),
-            num_training_steps=total_optimizer_steps,
-        )
+        # DEFERRED: avoid len() on lazy datasets to prevent eager chunking at init time.
+        # The scheduler is built on the first train_epoch() call when length is known.
+        self._scheduler_warmup = max(1, cfg.warmup_steps // self.grad_accum_steps)
+        self._scheduler_cycles = 0.5
+        self._scheduler_min_lr = 0.1
+        self.scheduler = None
 
         self.global_step = 0
         self.best_val_loss = float("inf")
@@ -230,6 +227,22 @@ class Trainer:
         tokens_seen = 0
 
         self.optimizer.zero_grad()
+
+        # Lazily initialize scheduler now that we know real loader length.
+        # This avoids forcing DocumentAwareDataset(lazy=True) to chunk all
+        # documents during Trainer construction.
+        if self.scheduler is None:
+            steps_per_epoch = math.ceil(
+                len(self.train_loader) / self.grad_accum_steps
+            )
+            total_optimizer_steps = steps_per_epoch * self.cfg.epochs
+            self.scheduler = get_cosine_schedule_with_warmup(
+                self.optimizer,
+                num_warmup_steps=self._scheduler_warmup,
+                num_training_steps=total_optimizer_steps,
+                num_cycles=self._scheduler_cycles,
+                min_lr_ratio=self._scheduler_min_lr,
+            )
 
         pbar = tqdm(
             self.train_loader,

--- a/quick_demo_cpu.py
+++ b/quick_demo_cpu.py
@@ -53,7 +53,8 @@ def main():
     cfg = HelixConfig.tiny(
         vocab_size=VOCABULARY_SIZE,
         seq_len=MAX_SEQ_LEN,
-        tokenizer_name="gpt2")
+        tokenizer_name="gpt2",
+        use_titans_memory=False)
 
     cfg.pad_token_id = tokenizer.pad_token_id
     cfg.eos_token_id = tokenizer.eos_token_id

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,4 @@ transformers==5.6.2
 datasets==4.8.4
 tiktoken>=0.11.0
 numpy>=1.24.0
+tqdm>=4.65.0

--- a/train-with-dataset-cicd-test.py
+++ b/train-with-dataset-cicd-test.py
@@ -1,0 +1,306 @@
+"""
+Integration test: DocumentAwareDataset + Trainer with mixed-length texts.
+
+Validates:
+1. Long texts (>= seq_len): stride=32 (no overlap) vs stride=16 (50% overlap)
+   trained for 15 epochs via the official Trainer — no substantial degradation.
+2. Short texts (< seq_len): explicit DocumentAwareDataset vs raw text list
+   passed to Trainer — equivalent results.
+3. 15-epoch training stability end-to-end.
+"""
+import sys
+import os
+import math
+import random
+
+# sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+import pandas as pd
+import torch
+from datasets import load_dataset
+from torch.utils.data import DataLoader
+
+from helix_lm import HelixConfig, HelixForCausalLM, HelixTokenizer, Trainer
+from helix_lm.dataset import DocumentAwareDataset, create_document_loader
+
+
+SEED = 42
+SEQ_LEN = 32
+N_SAMPLES = 500
+N_EPOCHS = 15
+BATCH_SIZE = 8
+DATASET_SLICES = 5_000
+
+
+def get_token_counts(texts, tokenizer):
+    """Return list of token counts for each raw text."""
+    return [len(tokenizer.encode(t, add_special_tokens=False)) for t in texts]
+
+
+def select_long_mixed(texts, counts, seq_len, n=N_SAMPLES):
+    """
+    Select a mix of barely-longer (seq_len … 1.5×) and considerably-longer
+    (> 2× seq_len) samples.
+    """
+    barely, considerable = [], []
+    for t, c in zip(texts, counts):
+        if c < seq_len:
+            continue
+        if c <= int(seq_len * 1.5):
+            barely.append(t)
+        elif c >= seq_len * 2:
+            considerable.append(t)
+
+    n_b = min(len(barely), n // 3)
+    n_c = min(len(considerable), n * 2 // 3)
+    chosen = []
+    if n_b:
+        chosen.extend(random.sample(barely, n_b))
+    if n_c:
+        chosen.extend(random.sample(considerable, n_c))
+
+    # back-fill if pool was lopsided
+    need = n - len(chosen)
+    pool = [t for t, c in zip(texts, counts) if c >= seq_len and t not in chosen]
+    if need > 0 and pool:
+        chosen.extend(random.sample(pool, min(need, len(pool))))
+
+    random.shuffle(chosen)
+    return chosen[:n]
+
+
+def select_short(texts, counts, seq_len, n=N_SAMPLES):
+    """Select texts strictly shorter than seq_len."""
+    pool = [t for t, c in zip(texts, counts) if 0 < c < seq_len]
+    if len(pool) >= n:
+        return random.sample(pool, n)
+    return pool
+
+
+def build_cfg(vocab_size):
+    return HelixConfig.tiny(
+        vocab_size=vocab_size,
+        seq_len=SEQ_LEN,
+        tokenizer_name="gpt2",
+        use_titans_memory=False,
+        batch_size=BATCH_SIZE,
+        lr=3e-4,
+        weight_decay=0.1,
+        epochs=N_EPOCHS,
+        warmup_steps=50,
+        grad_clip=1.0,
+    )
+
+
+def run_trainer(
+    model,
+    cfg,
+    tokenizer,
+    train_texts,
+    val_texts,
+    stride,
+    min_tail_len,
+    label,
+):
+    """
+    Run the official Trainer for N_EPOCHS.
+    Returns (final_train_loss, final_val_loss, final_ppl).
+    """
+    # Explicit DataLoader path (at-scale style)
+    train_loader = create_document_loader(
+        train_texts,
+        tokenizer,
+        seq_len=SEQ_LEN,
+        batch_size=BATCH_SIZE,
+        stride=stride,
+        shuffle=True,
+        drop_last=True,
+        min_tail_len=min_tail_len,
+        lazy=True,
+    )
+    val_loader = create_document_loader(
+        val_texts,
+        tokenizer,
+        seq_len=SEQ_LEN,
+        batch_size=BATCH_SIZE,
+        stride=SEQ_LEN,  # no overlap for eval
+        shuffle=False,
+        drop_last=False,
+        min_tail_len=min_tail_len,
+        lazy=True,
+    )
+
+    trainer = Trainer(
+        model=model,
+        cfg=cfg,
+        train_loader=train_loader,
+        val_loader=val_loader,
+        tokenizer=tokenizer,
+        output_dir=f"./checkpoints_smoke_{label}_s{stride}",
+        example_prompts=["Once upon a time", "The cat sat"],
+        generated_example_length=20,
+        grad_accum_steps=1,
+        use_amp=False,
+        min_tail_len=min_tail_len,
+        verbose=False,
+    )
+
+    history = trainer.train(num_epochs=N_EPOCHS, eval_every=max(1, N_EPOCHS // 3))
+
+    train_loss = history["train_loss"][-1] if history.get("train_loss") else float("inf")
+    val_loss = history["val_loss"][-1] if history.get("val_loss") else float("inf")
+    ppl = math.exp(min(val_loss, 20)) if val_loss != float("inf") else float("inf")
+
+    print(f"[{label}] stride={stride} | train={train_loss:.4f} | val={val_loss:.4f} | ppl={ppl:.2f}")
+    return train_loss, val_loss, ppl
+
+
+def test_long_stride_equivalence(texts, tokenizer, cfg):
+    """Compare stride=32 vs stride=16 on long texts."""
+    print("\n" + "=" * 60)
+    print("TEST: Long texts (>= seq_len) — stride equivalence")
+    print("=" * 60)
+
+    split = int(len(texts) * 0.9)
+    train, val = texts[:split], texts[split:]
+
+    # Run A: no overlap
+    model_a = HelixForCausalLM(cfg)
+    loss_a, _, ppl_a = run_trainer(
+        model_a, cfg, tokenizer, train, val, stride=32, min_tail_len=SEQ_LEN // 4, label="long"
+    )
+
+    # Run B: 50 % overlap
+    model_b = HelixForCausalLM(cfg)
+    loss_b, _, ppl_b = run_trainer(
+        model_b, cfg, tokenizer, train, val, stride=16, min_tail_len=SEQ_LEN // 4, label="long"
+    )
+
+    # Assertions
+    baseline = math.log(cfg.vocab_size)
+    assert loss_a < baseline * 0.9, "stride=32 not learning"
+    assert loss_b < baseline * 0.9, "stride=16 not learning"
+
+    ppl_ratio = max(ppl_a, ppl_b) / min(ppl_a, ppl_b) if min(ppl_a, ppl_b) > 0 else 1.0
+    assert ppl_ratio < 2.0, f"stride equivalence broken (ppl ratio {ppl_ratio:.2f})"
+
+    print(f"[PASS] stride=32 vs stride=16 equivalent (ppl ratio {ppl_ratio:.2f})")
+    return True
+
+
+def test_short_equivalence(texts, tokenizer, cfg):
+    """
+    Compare:
+      A) Explicit DocumentAwareDataset passed as DataLoader
+      B) Raw text list passed to Trainer (internal dataset creation)
+    """
+    print("\n" + "=" * 60)
+    print("TEST: Short texts (< seq_len) — Dataset vs raw list equivalence")
+    print("=" * 60)
+
+    split = int(len(texts) * 0.9)
+    train, val = texts[:split], texts[split:]
+
+    # Path A: explicit DocumentAwareDataset + DataLoader
+    train_loader_a = create_document_loader(
+        train, tokenizer, SEQ_LEN, BATCH_SIZE, stride=SEQ_LEN,
+        shuffle=True, drop_last=True, min_tail_len=1, lazy=True,
+    )
+    val_loader_a = create_document_loader(
+        val, tokenizer, SEQ_LEN, BATCH_SIZE, stride=SEQ_LEN,
+        shuffle=False, drop_last=False, min_tail_len=1, lazy=True,
+    )
+
+    model_a = HelixForCausalLM(cfg)
+    trainer_a = Trainer(
+        model=model_a, cfg=cfg,
+        train_loader=train_loader_a, val_loader=val_loader_a,
+        tokenizer=tokenizer,
+        output_dir="./checkpoints_smoke_short_explicit",
+        example_prompts=["Once upon a time"],
+        generated_example_length=20,
+        grad_accum_steps=1, use_amp=False, min_tail_len=1,
+        verbose=False,
+    )
+    hist_a = trainer_a.train(num_epochs=N_EPOCHS, eval_every=5)
+    loss_a = hist_a["train_loss"][-1] if hist_a.get("train_loss") else float("inf")
+
+    # Path B: raw list (Trainer internally creates DocumentAwareDataset)
+    model_b = HelixForCausalLM(cfg)
+    trainer_b = Trainer(
+        model=model_b, cfg=cfg,
+        train_texts=train, val_texts=val,
+        tokenizer=tokenizer,
+        output_dir="./checkpoints_smoke_short_raw",
+        example_prompts=["Once upon a time"],
+        generated_example_length=20,
+        grad_accum_steps=1, use_amp=False, min_tail_len=1,
+        verbose=False,
+    )
+    hist_b = trainer_b.train(num_epochs=N_EPOCHS, eval_every=5)
+    loss_b = hist_b["train_loss"][-1] if hist_b.get("train_loss") else float("inf")
+
+    print(f"[explicit] train_loss={loss_a:.4f}")
+    print(f"[raw_list] train_loss={loss_b:.4f}")
+
+    assert not math.isinf(loss_a) and not math.isnan(loss_a), "explicit path diverged"
+    assert not math.isinf(loss_b) and not math.isnan(loss_b), "raw list path diverged"
+
+    ratio = max(loss_a, loss_b) / min(loss_a, loss_b) if min(loss_a, loss_b) > 0 else 1.0
+    assert ratio < 1.5, f"Dataset vs raw diverged (ratio {ratio:.2f})"
+
+    print(f"[PASS] explicit vs raw list equivalent (loss ratio {ratio:.2f})")
+    return True
+
+
+def main():
+    random.seed(SEED)
+    torch.manual_seed(SEED)
+
+    # 1. Tokenizer
+    tokenizer = HelixTokenizer("gpt2")
+    vocab_size = len(tokenizer)
+    print(f"Vocab size: {vocab_size}")
+
+    # 2. Load dataset slice
+    print(f"Loading dataset (first {DATASET_SLICES} samples)...")
+    ds = load_dataset("david-thrower/tiny-stories-mini-96-seq-len-50000-samples")
+    texts_all = ds["train"]["text"][:DATASET_SLICES]
+
+    # 3. Tokenize via pandas (as requested)
+    df = pd.DataFrame({"text": texts_all})
+    df["n_tokens"] = df["text"].apply(
+        lambda t: len(tokenizer.encode(t, add_special_tokens=False))
+    )
+    counts = df["n_tokens"].tolist()
+
+    # 4. Select cohorts
+    texts_long = select_long_mixed(texts_all, counts, SEQ_LEN, N_SAMPLES)
+    texts_short = select_short(texts_all, counts, SEQ_LEN, N_SAMPLES)
+
+    long_counts = [len(tokenizer.encode(t, add_special_tokens=False)) for t in texts_long]
+    short_counts = [len(tokenizer.encode(t, add_special_tokens=False)) for t in texts_short]
+
+    print(f"\nLong cohort:  {len(texts_long)} samples  (tokens: {min(long_counts)}–{max(long_counts)})")
+    print(f"Short cohort: {len(texts_short)} samples  (tokens: {min(short_counts) if short_counts else 0}–{max(short_counts) if short_counts else 0})")
+
+    cfg = build_cfg(vocab_size)
+    cfg.pad_token_id = tokenizer.pad_token_id
+    cfg.eos_token_id = tokenizer.eos_token_id
+
+    # 5. Run tests
+    results = {
+        "long_stride_equiv": test_long_stride_equivalence(texts_long, tokenizer, cfg),
+        "short_ds_equiv": test_short_equivalence(texts_short, tokenizer, cfg),
+    }
+
+    print("\n" + "=" * 60)
+    print("SUMMARY")
+    print("=" * 60)
+    for name, ok in results.items():
+        print(f"  {name}: {'PASS' if ok else 'FAIL'}")
+    return 0 if all(results.values()) else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/train-with-dataset-cicd-test.py
+++ b/train-with-dataset-cicd-test.py
@@ -1,24 +1,18 @@
 """
 Integration test: DocumentAwareDataset + Trainer with mixed-length texts.
-
-Validates:
-1. Long texts (>= seq_len): stride=32 (no overlap) vs stride=16 (50% overlap)
-   trained for 15 epochs via the official Trainer — no substantial degradation.
-2. Short texts (< seq_len): explicit DocumentAwareDataset vs raw text list
-   passed to Trainer — equivalent results.
-3. 15-epoch training stability end-to-end.
+CICD-ready with live stdout logging.
 """
 import sys
 import os
 import math
 import random
+import copy
 
-# sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 
 import pandas as pd
 import torch
 from datasets import load_dataset
-from torch.utils.data import DataLoader
 
 from helix_lm import HelixConfig, HelixForCausalLM, HelixTokenizer, Trainer
 from helix_lm.dataset import DocumentAwareDataset, create_document_loader
@@ -32,16 +26,16 @@ BATCH_SIZE = 8
 DATASET_SLICES = 5_000
 
 
+def banner(text):
+    line = "=" * 60
+    print(f"\n{line}\n{text}\n{line}", flush=True)
+
+
 def get_token_counts(texts, tokenizer):
-    """Return list of token counts for each raw text."""
     return [len(tokenizer.encode(t, add_special_tokens=False)) for t in texts]
 
 
 def select_long_mixed(texts, counts, seq_len, n=N_SAMPLES):
-    """
-    Select a mix of barely-longer (seq_len … 1.5×) and considerably-longer
-    (> 2× seq_len) samples.
-    """
     barely, considerable = [], []
     for t, c in zip(texts, counts):
         if c < seq_len:
@@ -59,7 +53,6 @@ def select_long_mixed(texts, counts, seq_len, n=N_SAMPLES):
     if n_c:
         chosen.extend(random.sample(considerable, n_c))
 
-    # back-fill if pool was lopsided
     need = n - len(chosen)
     pool = [t for t, c in zip(texts, counts) if c >= seq_len and t not in chosen]
     if need > 0 and pool:
@@ -70,10 +63,10 @@ def select_long_mixed(texts, counts, seq_len, n=N_SAMPLES):
 
 
 def select_short(texts, counts, seq_len, n=N_SAMPLES):
-    """Select texts strictly shorter than seq_len."""
     pool = [t for t, c in zip(texts, counts) if 0 < c < seq_len]
     if len(pool) >= n:
         return random.sample(pool, n)
+    banner(f"WARNING: only {len(pool)} short texts found (requested {n})")
     return pool
 
 
@@ -92,42 +85,22 @@ def build_cfg(vocab_size):
     )
 
 
-def run_trainer(
-    model,
-    cfg,
-    tokenizer,
-    train_texts,
-    val_texts,
-    stride,
-    min_tail_len,
-    label,
-):
+def run_trainer(model, cfg, tokenizer, train_texts, val_texts, stride, min_tail_len, label):
     """
-    Run the official Trainer for N_EPOCHS.
+    Run the official Trainer for N_EPOCHS with live verbose output.
     Returns (final_train_loss, final_val_loss, final_ppl).
     """
-    # Explicit DataLoader path (at-scale style)
+    banner(f"[{label}] Starting {N_EPOCHS}-epoch training | stride={stride} | {len(train_texts)} train / {len(val_texts)} val")
+
     train_loader = create_document_loader(
-        train_texts,
-        tokenizer,
-        seq_len=SEQ_LEN,
-        batch_size=BATCH_SIZE,
-        stride=stride,
-        shuffle=True,
-        drop_last=True,
-        min_tail_len=min_tail_len,
-        lazy=True,
+        train_texts, tokenizer, seq_len=SEQ_LEN, batch_size=BATCH_SIZE,
+        stride=stride, shuffle=True, drop_last=True,
+        min_tail_len=min_tail_len, lazy=True,
     )
     val_loader = create_document_loader(
-        val_texts,
-        tokenizer,
-        seq_len=SEQ_LEN,
-        batch_size=BATCH_SIZE,
-        stride=SEQ_LEN,  # no overlap for eval
-        shuffle=False,
-        drop_last=False,
-        min_tail_len=min_tail_len,
-        lazy=True,
+        val_texts, tokenizer, seq_len=SEQ_LEN, batch_size=BATCH_SIZE,
+        stride=SEQ_LEN, shuffle=False, drop_last=False,
+        min_tail_len=min_tail_len, lazy=True,
     )
 
     trainer = Trainer(
@@ -142,7 +115,7 @@ def run_trainer(
         grad_accum_steps=1,
         use_amp=False,
         min_tail_len=min_tail_len,
-        verbose=False,
+        verbose=True,   # ← LIVE PRINTING
     )
 
     history = trainer.train(num_epochs=N_EPOCHS, eval_every=max(1, N_EPOCHS // 3))
@@ -151,57 +124,60 @@ def run_trainer(
     val_loss = history["val_loss"][-1] if history.get("val_loss") else float("inf")
     ppl = math.exp(min(val_loss, 20)) if val_loss != float("inf") else float("inf")
 
-    print(f"[{label}] stride={stride} | train={train_loss:.4f} | val={val_loss:.4f} | ppl={ppl:.2f}")
+    print(f"[{label}] RESULT | train={train_loss:.4f} | val={val_loss:.4f} | ppl={ppl:.2f}", flush=True)
     return train_loss, val_loss, ppl
 
 
-def test_long_stride_equivalence(texts, tokenizer, cfg):
-    """Compare stride=32 vs stride=16 on long texts."""
-    print("\n" + "=" * 60)
-    print("TEST: Long texts (>= seq_len) — stride equivalence")
-    print("=" * 60)
-
+def test_long_stride_equivalence(texts, tokenizer):
+    banner("TEST: Long texts (>= seq_len) — stride equivalence")
     split = int(len(texts) * 0.9)
     train, val = texts[:split], texts[split:]
 
+    cfg_a = build_cfg(len(tokenizer))
+    cfg_a.pad_token_id = tokenizer.pad_token_id
+    cfg_a.eos_token_id = tokenizer.eos_token_id
+
     # Run A: no overlap
-    model_a = HelixForCausalLM(cfg)
+    print("\n>>> Run A: stride=32 (no overlap)", flush=True)
+    model_a = HelixForCausalLM(cfg_a)
     loss_a, _, ppl_a = run_trainer(
-        model_a, cfg, tokenizer, train, val, stride=32, min_tail_len=SEQ_LEN // 4, label="long"
+        model_a, cfg_a, tokenizer, train, val,
+        stride=32, min_tail_len=SEQ_LEN // 4, label="longA"
     )
+
+    # Fresh config copy for Run B (defensive against mutation from save_pretrained)
+    cfg_b = copy.deepcopy(cfg_a)
 
     # Run B: 50 % overlap
-    model_b = HelixForCausalLM(cfg)
+    print("\n>>> Run B: stride=16 (50% overlap)", flush=True)
+    model_b = HelixForCausalLM(cfg_b)
     loss_b, _, ppl_b = run_trainer(
-        model_b, cfg, tokenizer, train, val, stride=16, min_tail_len=SEQ_LEN // 4, label="long"
+        model_b, cfg_b, tokenizer, train, val,
+        stride=16, min_tail_len=SEQ_LEN // 4, label="longB"
     )
 
-    # Assertions
-    baseline = math.log(cfg.vocab_size)
-    assert loss_a < baseline * 0.9, "stride=32 not learning"
-    assert loss_b < baseline * 0.9, "stride=16 not learning"
+    baseline = math.log(len(tokenizer))
+    assert loss_a < baseline * 0.95, f"stride=32 not learning ({loss_a:.4f} >= {baseline:.4f})"
+    assert loss_b < baseline * 0.95, f"stride=16 not learning ({loss_b:.4f} >= {baseline:.4f})"
 
     ppl_ratio = max(ppl_a, ppl_b) / min(ppl_a, ppl_b) if min(ppl_a, ppl_b) > 0 else 1.0
     assert ppl_ratio < 2.0, f"stride equivalence broken (ppl ratio {ppl_ratio:.2f})"
 
-    print(f"[PASS] stride=32 vs stride=16 equivalent (ppl ratio {ppl_ratio:.2f})")
+    banner(f"[PASS] stride=32 vs stride=16 equivalent (ppl ratio {ppl_ratio:.2f})")
     return True
 
 
-def test_short_equivalence(texts, tokenizer, cfg):
-    """
-    Compare:
-      A) Explicit DocumentAwareDataset passed as DataLoader
-      B) Raw text list passed to Trainer (internal dataset creation)
-    """
-    print("\n" + "=" * 60)
-    print("TEST: Short texts (< seq_len) — Dataset vs raw list equivalence")
-    print("=" * 60)
-
+def test_short_equivalence(texts, tokenizer):
+    banner("TEST: Short texts (< seq_len) — Dataset vs raw list equivalence")
     split = int(len(texts) * 0.9)
     train, val = texts[:split], texts[split:]
 
+    cfg = build_cfg(len(tokenizer))
+    cfg.pad_token_id = tokenizer.pad_token_id
+    cfg.eos_token_id = tokenizer.eos_token_id
+
     # Path A: explicit DocumentAwareDataset + DataLoader
+    print("\n>>> Path A: Explicit DocumentAwareDataset (custom loaders)", flush=True)
     train_loader_a = create_document_loader(
         train, tokenizer, SEQ_LEN, BATCH_SIZE, stride=SEQ_LEN,
         shuffle=True, drop_last=True, min_tail_len=1, lazy=True,
@@ -220,36 +196,37 @@ def test_short_equivalence(texts, tokenizer, cfg):
         example_prompts=["Once upon a time"],
         generated_example_length=20,
         grad_accum_steps=1, use_amp=False, min_tail_len=1,
-        verbose=False,
+        verbose=True,
     )
     hist_a = trainer_a.train(num_epochs=N_EPOCHS, eval_every=5)
     loss_a = hist_a["train_loss"][-1] if hist_a.get("train_loss") else float("inf")
 
     # Path B: raw list (Trainer internally creates DocumentAwareDataset)
-    model_b = HelixForCausalLM(cfg)
+    print("\n>>> Path B: Raw text list (Trainer internal dataset creation)", flush=True)
+    model_b = HelixForCausalLM(copy.deepcopy(cfg))
     trainer_b = Trainer(
-        model=model_b, cfg=cfg,
+        model=model_b, cfg=copy.deepcopy(cfg),
         train_texts=train, val_texts=val,
         tokenizer=tokenizer,
         output_dir="./checkpoints_smoke_short_raw",
         example_prompts=["Once upon a time"],
         generated_example_length=20,
         grad_accum_steps=1, use_amp=False, min_tail_len=1,
-        verbose=False,
+        verbose=True,
     )
     hist_b = trainer_b.train(num_epochs=N_EPOCHS, eval_every=5)
     loss_b = hist_b["train_loss"][-1] if hist_b.get("train_loss") else float("inf")
 
-    print(f"[explicit] train_loss={loss_a:.4f}")
+    print(f"\n[explicit] train_loss={loss_a:.4f}")
     print(f"[raw_list] train_loss={loss_b:.4f}")
 
-    assert not math.isinf(loss_a) and not math.isnan(loss_a), "explicit path diverged"
-    assert not math.isinf(loss_b) and not math.isnan(loss_b), "raw list path diverged"
+    assert not math.isinf(loss_a) and not math.isnan(loss_a), "Path A diverged"
+    assert not math.isinf(loss_b) and not math.isnan(loss_b), "Path B diverged"
 
     ratio = max(loss_a, loss_b) / min(loss_a, loss_b) if min(loss_a, loss_b) > 0 else 1.0
     assert ratio < 1.5, f"Dataset vs raw diverged (ratio {ratio:.2f})"
 
-    print(f"[PASS] explicit vs raw list equivalent (loss ratio {ratio:.2f})")
+    banner(f"[PASS] explicit vs raw list equivalent (loss ratio {ratio:.2f})")
     return True
 
 
@@ -257,49 +234,49 @@ def main():
     random.seed(SEED)
     torch.manual_seed(SEED)
 
-    # 1. Tokenizer
+    banner("SETUP")
     tokenizer = HelixTokenizer("gpt2")
     vocab_size = len(tokenizer)
-    print(f"Vocab size: {vocab_size}")
+    print(f"Vocab size: {vocab_size}", flush=True)
 
-    # 2. Load dataset slice
-    print(f"Loading dataset (first {DATASET_SLICES} samples)...")
+    print(f"Loading dataset (first {DATASET_SLICES} samples)...", flush=True)
     ds = load_dataset("david-thrower/tiny-stories-mini-96-seq-len-50000-samples")
     texts_all = ds["train"]["text"][:DATASET_SLICES]
 
-    # 3. Tokenize via pandas (as requested)
+    # Tokenize via pandas (as requested)
     df = pd.DataFrame({"text": texts_all})
+    print("Tokenizing for cohort selection...", flush=True)
     df["n_tokens"] = df["text"].apply(
         lambda t: len(tokenizer.encode(t, add_special_tokens=False))
     )
     counts = df["n_tokens"].tolist()
 
-    # 4. Select cohorts
     texts_long = select_long_mixed(texts_all, counts, SEQ_LEN, N_SAMPLES)
     texts_short = select_short(texts_all, counts, SEQ_LEN, N_SAMPLES)
 
     long_counts = [len(tokenizer.encode(t, add_special_tokens=False)) for t in texts_long]
     short_counts = [len(tokenizer.encode(t, add_special_tokens=False)) for t in texts_short]
 
-    print(f"\nLong cohort:  {len(texts_long)} samples  (tokens: {min(long_counts)}–{max(long_counts)})")
-    print(f"Short cohort: {len(texts_short)} samples  (tokens: {min(short_counts) if short_counts else 0}–{max(short_counts) if short_counts else 0})")
+    print(f"Long cohort:  {len(texts_long)} samples  (tokens: {min(long_counts) if long_counts else 'n/a'}–{max(long_counts) if long_counts else 'n/a'})", flush=True)
+    print(f"Short cohort: {len(texts_short)} samples  (tokens: {min(short_counts) if short_counts else 'n/a'}–{max(short_counts) if short_counts else 'n/a'})", flush=True)
 
-    cfg = build_cfg(vocab_size)
-    cfg.pad_token_id = tokenizer.pad_token_id
-    cfg.eos_token_id = tokenizer.eos_token_id
+    # Guard against empty cohorts
+    assert len(texts_long) >= 10, f"Need >=10 long texts, got {len(texts_long)}"
+    assert len(texts_short) >= 10, f"Need >=10 short texts, got {len(texts_short)}"
 
-    # 5. Run tests
     results = {
-        "long_stride_equiv": test_long_stride_equivalence(texts_long, tokenizer, cfg),
-        "short_ds_equiv": test_short_equivalence(texts_short, tokenizer, cfg),
+        "long_stride_equiv": test_long_stride_equivalence(texts_long, tokenizer),
+        "short_ds_equiv": test_short_equivalence(texts_short, tokenizer),
     }
 
-    print("\n" + "=" * 60)
-    print("SUMMARY")
-    print("=" * 60)
+    banner("FINAL SUMMARY")
     for name, ok in results.items():
-        print(f"  {name}: {'PASS' if ok else 'FAIL'}")
-    return 0 if all(results.values()) else 1
+        status = "PASS" if ok else "FAIL"
+        print(f"  {name}: {status}", flush=True)
+
+    all_ok = all(results.values())
+    print(f"\nOverall: {'ALL PASSED' if all_ok else 'SOME FAILED'}", flush=True)
+    return 0 if all_ok else 1
 
 
 if __name__ == "__main__":


### PR DESCRIPTION

Numerous bug fixes from branches #9 , #18, ... 


This PR delivers a broad stability, efficiency, and usability update focused on four themes: **bug fixes**, **memory efficiency**, **training UX**, and **CI/CD hardening**.

### 🔧 Core Bug Fixes
- **Eliminated duplicate LM head**: `HelixForCausalLM` now instantiates `HelixLMCore(..., create_output_head=False)`, removing a dead-weight tied head that caused parameter and gradient duplication when wrapping the core model.
- **Hardened dtype serialization**: `HelixConfig` now consistently strips and re-applies the `torch.` prefix when converting between `torch.dtype` objects and strings during `save_pretrained` / `from_pretrained`, preventing RoPE and config reload failures.
- **Fixed gradient accumulation edge case**: the final, incomplete accumulation step now correctly divides by the actual accumulated count instead of the target steps, removing noisy loss spikes at batch boundaries.
- **Defensive dataset batching**: `DocumentAwareDataset` was refactored to handle padding, striding/overlap, and lazy chunking more robustly (see large `dataset.py` diff).

### 🧠 Memory & Efficiency
- **Memory-efficient forward pass**: added `memory_efficient_forward` config flag. When enabled, the forward pass deletes the full `logits` tensor immediately after computing the shifted/flattened loss, cutting peak activation memory for long sequences.
- **Optimized loss computation**: flattened logits and labels with `reshape(-1, vocab_size)` before `CrossEntropyLoss` to avoid large intermediate views.
- **RoPE dtype flexibility**: `precompute_freqs_cis` now accepts `None`, strings, or `torch.dtype` and safely defaults to `float32`.

### 🚀 Training UX
- **Live progress bars**: integrated `tqdm` in both train and validation loops, displaying loss, perplexity, learning rate, and tokens/sec in real time.
- **Silent / verbose mode**: added `verbose` flag to `Trainer` to suppress print chatter when running headless or in CI.
- **Auto device placement**: `HelixForCausalLM` now resolves `config.device="auto"` to `cuda > mps > cpu` on instantiation and emits a warning if it falls back to CPU while a GPU is available.
- **Injectable data loaders**: `Trainer` now accepts optional `train_loader` / `val_loader`, enabling custom dataset pipelines (e.g., pre-batched streaming) without bypassing the trainer.
- **Lazy scheduler initialization**: the cosine-with-warmup scheduler is deferred until the first training epoch when the lazy dataset length is known, avoiding eager chunking of gigabyte-scale corpora at import time.
- **Titans defaults & guardrails**: switched `use_titans_memory` default to `True`, but added a `validate_config()` warning when it is enabled on small models (<50M params, short seq len) where the per-batch state reset limits benefit.

### 🧪 Testing & CI
- **New integration / smoke test** (`train-with-dataset-cicd-test.py`):
  - Tests `DocumentAwareDataset` with 50 % stride overlap vs. no-overlap to ensure training equivalence.
  - Tests short-text (`< seq_len`) vs. explicit custom-loader paths to verify parity between internal dataset creation and injected loaders.
- **CI expansion**: added a 90-minute GitHub Actions step that runs the new smoke test on every push.

### 📝 Docs & Examples
- **Updated parameter table**: replaced placeholder “-” values with actual parameter counts for both char-level and GPT-2 vocab sizes across all presets (tiny → xxl).
- **HF examples**: updated `train_hf_full.py` and CPU demos to use `use_titans_memory=False` for stable baselines, and switched tokenizer calls to `return_tensors="pt"`.
- **Tokenizer helpers**: exposed `save_pretrained` and `push_to_hub` on `HelixTokenizer` for one-line HF Hub uploads.

### Dependency Note
- Added `tqdm>=4.65.0` to `requirements.txt`.