### PR TITLE
Downgrade torch version to 2.6.0

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-torch==2.11.0
+torch==2.6.0
 transformers==5.6.2
 datasets==4.8.4
 tiktoken>=0.11.0


### PR DESCRIPTION
The Python 3.12 Torch container pytorch/pytorch:2.6.0-cuda12.4-cudnn9-devel uses 2.6.0. I want to standardize the version to work both in GPU containers we can run in HF jobs, Paperspace, and on Kubernetes and use the same version in CPU CICD tests ...